### PR TITLE
ci: hardcode VPS IP via secret, drop runtime Scaleway IP lookup

### DIFF
--- a/.github/workflows/backend-build-push.yml
+++ b/.github/workflows/backend-build-push.yml
@@ -133,26 +133,10 @@ jobs:
       - name: Wait for registry propagation
         run: sleep 15
 
-      - name: Fetch VPS public IP from Scaleway
-        env:
-          SCW_SECRET_KEY: ${{ secrets.SCALEWAY_SECRET_KEY }}
-          SCW_ZONE: ${{ secrets.SCALEWAY_ZONE }}
-          SCW_INSTANCE_ID: ${{ secrets.SCALEWAY_INSTANCE_ID }}
-        run: |
-          set -euo pipefail
-          resp=$(curl -sS -H "X-Auth-Token: $SCW_SECRET_KEY" \
-            "https://api.scaleway.com/instance/v1/zones/${SCW_ZONE}/servers/${SCW_INSTANCE_ID}")
-          ip=$(echo "$resp" | jq -r '.server.public_ip.address // .server.public_ips[0].address // empty')
-          if [ -z "$ip" ] || [ "$ip" = "null" ]; then
-            echo "Failed to resolve VPS IP" >&2
-            exit 1
-          fi
-          echo "VPS_HOST=$ip" >> "$GITHUB_ENV"
-
       - name: Pull new image and restart api on VPS
         uses: appleboy/ssh-action@v1.0.3
         with:
-          host: ${{ env.VPS_HOST }}
+          host: ${{ secrets.VPS_IP }}
           username: root
           key: ${{ secrets.VPS_SSH_KEY }}
           port: 22

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -18,22 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Fetch VPS public IP from Scaleway
-        env:
-          SCW_SECRET_KEY: ${{ secrets.SCALEWAY_SECRET_KEY }}
-          SCW_ZONE: ${{ secrets.SCALEWAY_ZONE }}
-          SCW_INSTANCE_ID: ${{ secrets.SCALEWAY_INSTANCE_ID }}
-        run: |
-          set -euo pipefail
-          resp=$(curl -sS -H "X-Auth-Token: $SCW_SECRET_KEY" \
-            "https://api.scaleway.com/instance/v1/zones/${SCW_ZONE}/servers/${SCW_INSTANCE_ID}")
-          ip=$(echo "$resp" | jq -r '.server.public_ip.address // .server.public_ips[0].address // empty')
-          if [ -z "$ip" ] || [ "$ip" = "null" ]; then
-            echo "Failed to resolve VPS IP" >&2
-            exit 1
-          fi
-          echo "VPS_HOST=$ip" >> "$GITHUB_ENV"
-
       - name: Compute REGISTRY_ENDPOINT
         run: echo "REGISTRY_ENDPOINT=rg.fr-par.scw.cloud/coach-os" >> "$GITHUB_ENV"
 
@@ -45,7 +29,7 @@ jobs:
           SCW_DEFAULT_PROJECT_ID: ${{ secrets.SCALEWAY_PROJECT_ID }}
           REGISTRY_ENDPOINT: ${{ env.REGISTRY_ENDPOINT }}
         with:
-          host: ${{ env.VPS_HOST }}
+          host: ${{ secrets.VPS_IP }}
           username: root
           key: ${{ secrets.VPS_SSH_KEY }}
           port: 22

--- a/.github/workflows/frontend-build-push.yml
+++ b/.github/workflows/frontend-build-push.yml
@@ -67,26 +67,10 @@ jobs:
       - name: Wait for registry propagation
         run: sleep 15
 
-      - name: Fetch VPS public IP from Scaleway
-        env:
-          SCW_SECRET_KEY: ${{ secrets.SCALEWAY_SECRET_KEY }}
-          SCW_ZONE: ${{ secrets.SCALEWAY_ZONE }}
-          SCW_INSTANCE_ID: ${{ secrets.SCALEWAY_INSTANCE_ID }}
-        run: |
-          set -euo pipefail
-          resp=$(curl -sS -H "X-Auth-Token: $SCW_SECRET_KEY" \
-            "https://api.scaleway.com/instance/v1/zones/${SCW_ZONE}/servers/${SCW_INSTANCE_ID}")
-          ip=$(echo "$resp" | jq -r '.server.public_ip.address // .server.public_ips[0].address // empty')
-          if [ -z "$ip" ] || [ "$ip" = "null" ]; then
-            echo "Failed to resolve VPS IP" >&2
-            exit 1
-          fi
-          echo "VPS_HOST=$ip" >> "$GITHUB_ENV"
-
       - name: Pull new image and restart frontend on VPS
         uses: appleboy/ssh-action@v1.0.3
         with:
-          host: ${{ env.VPS_HOST }}
+          host: ${{ secrets.VPS_IP }}
           username: root
           key: ${{ secrets.VPS_SSH_KEY }}
           port: 22


### PR DESCRIPTION
  The IP is reserved (routed_ipv4) so it never changes — fetching it from
  the Scaleway API every deploy added a permission requirement
  (InstancesReadOnly) and a failure mode for no benefit.