### PR TITLE
ci: hardcode VPS IP, add docker login, fix terraform errors

### DIFF
--- a/.github/workflows/backend-build-push.yml
+++ b/.github/workflows/backend-build-push.yml
@@ -135,13 +135,18 @@ jobs:
 
       - name: Pull new image and restart api on VPS
         uses: appleboy/ssh-action@v1.0.3
+        env:
+          SCW_SECRET_KEY: ${{ secrets.SCALEWAY_SECRET_KEY }}
         with:
           host: ${{ secrets.VPS_IP }}
           username: root
           key: ${{ secrets.VPS_SSH_KEY }}
           port: 22
+          envs: SCW_SECRET_KEY
           script: |
+            set -euo pipefail
             cd /app
+            echo "$SCW_SECRET_KEY" | docker login rg.fr-par.scw.cloud -u nologin --password-stdin
             for i in 1 2 3; do
               if docker compose pull api; then break; fi
               [ $i -lt 3 ] && sleep 10 || exit 1

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -88,6 +88,9 @@ jobs:
               exit 1
             fi
 
+            # Login to Scaleway Container Registry (idempotent — refreshes creds each deploy)
+            echo "$SCW_SECRET_KEY" | docker login rg.fr-par.scw.cloud -u nologin --password-stdin
+
             # Pull latest images and bring everything up
             docker compose pull
             docker compose up -d

--- a/.github/workflows/frontend-build-push.yml
+++ b/.github/workflows/frontend-build-push.yml
@@ -69,13 +69,18 @@ jobs:
 
       - name: Pull new image and restart frontend on VPS
         uses: appleboy/ssh-action@v1.0.3
+        env:
+          SCW_SECRET_KEY: ${{ secrets.SCALEWAY_SECRET_KEY }}
         with:
           host: ${{ secrets.VPS_IP }}
           username: root
           key: ${{ secrets.VPS_SSH_KEY }}
           port: 22
+          envs: SCW_SECRET_KEY
           script: |
+            set -euo pipefail
             cd /app
+            echo "$SCW_SECRET_KEY" | docker login rg.fr-par.scw.cloud -u nologin --password-stdin
             for i in 1 2 3; do
               if docker compose pull frontend; then break; fi
               [ $i -lt 3 ] && sleep 10 || exit 1


### PR DESCRIPTION
## Summary
- Drop runtime Scaleway IP-fetch from all 3 workflows; use VPS_IP secret directly (IP is reserved, never changes — removes a permission requirement and a failure mode)
- Add 'docker login' step to every VPS deploy so registry creds are always fresh (survives VPS rebuilds and key rotation, no manual bootstrap needed)
- Terraform fixes: bssd → sbs_5k volume type, DKIM record uses dkim_name, drop scaleway_iam_ssh_key resource (IAM perms gap, key registered manually + auto-attached)
- Fix .gitignore to exclude tfplan files without extension

## Test plan
- [ ] All three workflows go green on merge
- [ ] https://coach-os.be returns frontend
- [ ] https://coach-os.be/api/health returns 200
- [ ] DB migrations apply cleanly