### PR TITLE
fix(ci): pin Scaleway Secret Manager lookup to fr-par

### DIFF
--- a/.github/workflows/backend-build-push.yml
+++ b/.github/workflows/backend-build-push.yml
@@ -105,6 +105,7 @@ jobs:
           secret-key: ${{ secrets.SCALEWAY_SECRET_KEY }}
           default-project-id: ${{ secrets.SCALEWAY_PROJECT_ID }}
           default-organization-id: ${{ secrets.SCALEWAY_DEFAULT_ORGANIZATION_ID }}
+          default-region: fr-par
 
       - name: Export connection string for EF Core
         run: |


### PR DESCRIPTION
Workflow was falling back to SDK default region (nl-ams); our secrets live in fr-par.