### PR TITLE
fix(ci): add dozzle to nginx validator hosts

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -79,6 +79,7 @@ jobs:
             if ! docker run --rm \
                   --add-host api:127.0.0.1 \
                   --add-host frontend:127.0.0.1 \
+                  --add-host dozzle:127.0.0.1 \
                   -v /app/nginx/nginx.conf:/etc/nginx/nginx.conf:ro \
                   -v /app/nginx/conf.d:/etc/nginx/conf.d:ro \
                   -v /etc/letsencrypt:/etc/letsencrypt:ro \

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -28,12 +28,13 @@ jobs:
           SCW_DEFAULT_ORGANIZATION_ID: ${{ secrets.SCALEWAY_DEFAULT_ORGANIZATION_ID }}
           SCW_DEFAULT_PROJECT_ID: ${{ secrets.SCALEWAY_PROJECT_ID }}
           REGISTRY_ENDPOINT: ${{ env.REGISTRY_ENDPOINT }}
+          DOZZLE_PASSWORD: ${{ secrets.DOZZLE_PASSWORD }}
         with:
           host: ${{ secrets.VPS_IP }}
           username: root
           key: ${{ secrets.VPS_SSH_KEY }}
           port: 22
-          envs: SCW_SECRET_KEY,SCW_DEFAULT_ORGANIZATION_ID,SCW_DEFAULT_PROJECT_ID,REGISTRY_ENDPOINT
+          envs: SCW_SECRET_KEY,SCW_DEFAULT_ORGANIZATION_ID,SCW_DEFAULT_PROJECT_ID,REGISTRY_ENDPOINT,DOZZLE_PASSWORD
           script: |
             set -euo pipefail
             cd /app
@@ -63,6 +64,7 @@ jobs:
             SCW_DEFAULT_ORGANIZATION_ID=${SCW_DEFAULT_ORGANIZATION_ID}
             SCW_DEFAULT_PROJECT_ID=${SCW_DEFAULT_PROJECT_ID}
             SCW_REGION=fr-par
+            DOZZLE_PASSWORD=${DOZZLE_PASSWORD}
             EOF
 
             # Validate compose syntax (rolls back on failure)

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -58,6 +58,39 @@ services:
         max-size: "10m"
         max-file: "3"
 
+  # Live container log viewer at https://coach-os.be/_logs/ (basic auth).
+  # Reads the host docker socket read-only — only sees containers, can't
+  # exec into them or stop them.
+  dozzle:
+    image: amir20/dozzle:latest
+    container_name: coach-os-dozzle
+    restart: unless-stopped
+
+    environment:
+      DOZZLE_USERNAME: admin
+      DOZZLE_PASSWORD: ${DOZZLE_PASSWORD}
+      DOZZLE_BASE: /_logs
+      DOZZLE_NO_ANALYTICS: "true"
+
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/_logs/healthcheck"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+
+    networks:
+      - coach-os-network
+
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
   nginx:
     image: nginx:alpine
     container_name: coach-os-nginx
@@ -75,6 +108,7 @@ services:
     depends_on:
       - api
       - frontend
+      - dozzle
 
     networks:
       - coach-os-network

--- a/infrastructure/nginx/conf.d/coach-os.conf
+++ b/infrastructure/nginx/conf.d/coach-os.conf
@@ -67,6 +67,22 @@ server {
         access_log off;
     }
 
+    # ── Dozzle (live container log viewer) ───────────────────────────────────
+    # Dozzle handles its own basic auth via DOZZLE_USERNAME/PASSWORD env vars;
+    # nginx just proxies (with WebSocket upgrade for live tail).
+    location /_logs/ {
+        proxy_pass http://dozzle:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 86400s;  # long-lived WebSocket for live log tail
+        access_log off;
+    }
+
     # ── Frontend ─────────────────────────────────────────────────────────────
 
     location / {


### PR DESCRIPTION
Resolves the failed deploy from PR #25 — validator container couldn't resolve 'dozzle' upstream.