### PR TITLE
fix(infra): runtime DNS for all nginx upstreams

### DIFF
--- a/infrastructure/nginx/conf.d/coach-os.conf
+++ b/infrastructure/nginx/conf.d/coach-os.conf
@@ -36,12 +36,18 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
+    # All upstreams use a variable so nginx resolves DNS at request time
+    # via the global resolver in nginx.conf. Without this, nginx refuses
+    # to boot if any single upstream container is temporarily down (one
+    # crashed backend = entire site offline).
+
     # ── API ──────────────────────────────────────────────────────────────────
 
     # Stricter rate limit for /api/auth/* to slow credential-stuffing.
     location ~ ^/api/auth/ {
         limit_req zone=auth_zone burst=5 nodelay;
-        proxy_pass http://api:8080;
+        set $api_upstream "api:8080";
+        proxy_pass http://$api_upstream;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -51,7 +57,8 @@ server {
 
     location /api/ {
         limit_req zone=api_zone burst=20 nodelay;
-        proxy_pass http://api:8080;
+        set $api_upstream "api:8080";
+        proxy_pass http://$api_upstream;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -62,7 +69,8 @@ server {
 
     # Health endpoint without rate limiting (for uptime monitors).
     location = /api/health {
-        proxy_pass http://api:8080/health;
+        set $api_upstream "api:8080";
+        proxy_pass http://$api_upstream/health;
         proxy_set_header Host $host;
         access_log off;
     }
@@ -91,7 +99,8 @@ server {
 
     location / {
         limit_req zone=front_zone burst=50 nodelay;
-        proxy_pass http://frontend:3000;
+        set $frontend_upstream "frontend:3000";
+        proxy_pass http://$frontend_upstream;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";


### PR DESCRIPTION
Stops a single backend crash from taking the whole site down.