### PR TITLE
fix(infra): TEM autoconfig + frontend healthcheck

### DIFF
--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -43,8 +43,10 @@ services:
     container_name: coach-os-frontend
     restart: unless-stopped
 
+    # Next.js redirects '/' to a locale-prefixed path (307), which wget --spider
+    # treats as an error. Use node to treat anything < 500 as healthy.
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:3000/"]
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:3000/', r => process.exit(r.statusCode < 500 ? 0 : 1)).on('error', () => process.exit(1))"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/infrastructure/terraform/dns.tf
+++ b/infrastructure/terraform/dns.tf
@@ -1,10 +1,8 @@
 # DNS records on Scaleway Domains for coach-os.be.
 # The domain itself must be registered/transferred at Scaleway before these apply.
-
-locals {
-  tem_spf_record   = "v=spf1 include:_spf.tem.scw.cloud -all"
-  tem_dmarc_record = "v=DMARC1; p=quarantine; rua=mailto:postmaster@${var.domain_name}"
-}
+#
+# SPF/DKIM/DMARC records are NOT managed here — they're auto-created by
+# scaleway_tem_domain.coach_os (autoconfig = true). See main.tf.
 
 # Apex: coach-os.be → VPS public IP
 resource "scaleway_domain_record" "apex" {
@@ -22,31 +20,4 @@ resource "scaleway_domain_record" "www" {
   type     = "A"
   data     = scaleway_instance_ip.vps.address
   ttl      = 300
-}
-
-# Transactional Email SPF
-resource "scaleway_domain_record" "spf" {
-  dns_zone = var.domain_name
-  name     = ""
-  type     = "TXT"
-  data     = local.tem_spf_record
-  ttl      = 3600
-}
-
-# Transactional Email DKIM (Scaleway generates the key; attach via the TEM resource output)
-resource "scaleway_domain_record" "dkim" {
-  dns_zone = var.domain_name
-  name     = scaleway_tem_domain.coach_os.dkim_name
-  type     = "TXT"
-  data     = scaleway_tem_domain.coach_os.dkim_config
-  ttl      = 3600
-}
-
-# DMARC
-resource "scaleway_domain_record" "dmarc" {
-  dns_zone = var.domain_name
-  name     = "_dmarc"
-  type     = "TXT"
-  data     = local.tem_dmarc_record
-  ttl      = 3600
 }

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -110,12 +110,15 @@ resource "scaleway_rdb_privilege" "coach_os" {
 }
 
 # ── Transactional Email domain ───────────────────────────────────────────────
-# The domain must be DNS-verified before it can send; the records for that are
-# created in dns.tf to avoid a circular dependency.
+# autoconfig = true lets Scaleway create and maintain the SPF/DKIM/DMARC
+# records directly in Scaleway Domains. We previously managed them manually
+# in dns.tf but the DKIM value drifted out of sync with TEM's expectations,
+# blocking domain verification.
 
 resource "scaleway_tem_domain" "coach_os" {
   project_id = var.scw_project_id
   region     = var.scw_region
   name       = var.domain_name
   accept_tos = true
+  autoconfig = true
 }


### PR DESCRIPTION
Enables Scaleway-managed SPF/DKIM/DMARC and fixes frontend false-positive unhealthy status.