### PR TITLE
fix: atomic auth/confirmation + org switcher UI

### DIFF
--- a/backend/CoachOS.Application/Dashboard/DashboardService.cs
+++ b/backend/CoachOS.Application/Dashboard/DashboardService.cs
@@ -34,10 +34,8 @@ public class DashboardService(
         // Enrollment count
         var totalEnrollments = await enrollmentRepo.CountActiveByOrganizationAsync(organizationId, ct);
 
-        // Trainer count
-        var trainers =
-            await userLookup.GetOrganizationMembersAsync(organizationId, ct);
-        var activeTrainerCount = trainers.Count;
+        // Trainer count — enkel rol Trainer, admins uitgesloten.
+        var activeTrainerCount = await userLookup.CountActiveTrainersAsync(organizationId, ct);
 
         // Tennis club count
         var clubs =

--- a/backend/CoachOS.Application/StudentConfirmation/StudentConfirmationService.cs
+++ b/backend/CoachOS.Application/StudentConfirmation/StudentConfirmationService.cs
@@ -54,6 +54,14 @@ public class StudentConfirmationService(
         if (series is null)
             return Result<ConfirmResultDto>.Fail(new Error(ErrorCodes.NotFound, "Lessenreeks niet gevonden."));
 
+        // Atomisch de token claimen: voorkomt dubbele bevestiging als de student
+        // twee keer op "Bevestigen" tikt (dubbele Payment row anders gemaakt).
+        var claimed = await tokenRepo.TryClaimResponseAsync(
+            token.Id, ConfirmationResponse.Confirmed, DateTime.UtcNow, ct);
+        if (!claimed)
+            return Result<ConfirmResultDto>.Fail(
+                new Error(ErrorCodes.Validation, "Deze bevestiging is al verwerkt."));
+
         // Cash: mark paid immediately, create Payment(Paid, Cash)
         Payment payment = new()
         {
@@ -68,8 +76,6 @@ public class StudentConfirmationService(
         await paymentRepo.AddAsync(payment, ct);
 
         assignment.Status = ScheduleAssignmentStatus.Confirmed;
-        token.Response = ConfirmationResponse.Confirmed;
-        token.RespondedAt = DateTime.UtcNow;
 
         ConfirmEnrollmentStatuses(assignment);
         await paymentRepo.SaveChangesAsync(ct);
@@ -90,11 +96,15 @@ public class StudentConfirmationService(
             return Result<List<AvailableSlotDto>>.Fail(
                 new Error(ErrorCodes.Validation, "Deze bevestiging is al verwerkt."));
 
+        // Atomisch declinen — idem redenering als Confirm.
+        var claimed = await tokenRepo.TryClaimResponseAsync(
+            token.Id, ConfirmationResponse.Declined, DateTime.UtcNow, ct);
+        if (!claimed)
+            return Result<List<AvailableSlotDto>>.Fail(
+                new Error(ErrorCodes.Validation, "Deze bevestiging is al verwerkt."));
+
         var assignment = token.ScheduleAssignment;
         assignment.Status = ScheduleAssignmentStatus.Declined;
-        token.Response = ConfirmationResponse.Declined;
-        token.RespondedAt = DateTime.UtcNow;
-
         await tokenRepo.SaveChangesAsync(ct);
 
         var slots = await GetAvailableSlotsForAssignmentAsync(token, ct);

--- a/backend/CoachOS.Domain/Interfaces/IAssignmentConfirmationTokenRepository.cs
+++ b/backend/CoachOS.Domain/Interfaces/IAssignmentConfirmationTokenRepository.cs
@@ -14,4 +14,15 @@ public interface IAssignmentConfirmationTokenRepository
         IEnumerable<AssignmentConfirmationToken> tokens, CancellationToken ct = default);
 
     Task SaveChangesAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Atomisch de Response van <c>Pending</c> naar <paramref name="target"/> flippen.
+    /// Retourneert true als de update één rij raakte (pending was), anders false
+    /// (al verwerkt door een parallel request). Voorkomt double-confirm / double-decline.
+    /// </summary>
+    Task<bool> TryClaimResponseAsync(
+        Guid tokenId,
+        Domain.Enums.ConfirmationResponse target,
+        DateTime now,
+        CancellationToken ct = default);
 }

--- a/backend/CoachOS.Domain/Interfaces/IMagicLinkTokenRepository.cs
+++ b/backend/CoachOS.Domain/Interfaces/IMagicLinkTokenRepository.cs
@@ -7,4 +7,12 @@ public interface IMagicLinkTokenRepository
     Task<MagicLinkToken?> GetByTokenHashAsync(string tokenHash, CancellationToken ct = default);
     Task AddAsync(MagicLinkToken token, CancellationToken ct = default);
     Task SaveChangesAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Atomisch de token consumeren: markeert <c>UsedAt</c> op <paramref name="now"/> als
+    /// de token bestaat, nog niet gebruikt is én nog niet verlopen. Bij succes wordt de
+    /// geconsumeerde entity teruggegeven; anders null. Voorkomt race-condities waarbij
+    /// twee parallelle redeem-requests dezelfde token zouden kunnen inwisselen.
+    /// </summary>
+    Task<MagicLinkToken?> TryConsumeAsync(string tokenHash, DateTime now, CancellationToken ct = default);
 }

--- a/backend/CoachOS.Domain/Interfaces/IUserLookupService.cs
+++ b/backend/CoachOS.Domain/Interfaces/IUserLookupService.cs
@@ -6,6 +6,13 @@ public interface IUserLookupService
     Task<string?> GetUserNameByIdAsync(Guid id, CancellationToken ct = default);
     Task<List<(Guid Id, string FullName)>> GetOrganizationMembersAsync(Guid organizationId, CancellationToken ct = default);
     Task<bool> IsActiveTrainerAsync(Guid trainerId, Guid organizationId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Telt actieve memberships in deze organisatie met uitsluitend rol Trainer.
+    /// Admins tellen hier NIET mee, ook al kunnen ze zelf lesgeven — voor dashboard-
+    /// statistieken willen we enkel de "echte" trainers.
+    /// </summary>
+    Task<int> CountActiveTrainersAsync(Guid organizationId, CancellationToken ct = default);
     Task<Dictionary<Guid, (string FullName, string Email)>> GetUserNamesAndEmailsByIdsAsync(IEnumerable<Guid> ids, CancellationToken ct = default);
     Task<(string FullName, string Email)?> GetUserInfoByIdAsync(Guid id, CancellationToken ct = default);
 }

--- a/backend/CoachOS.Infrastructure/Identity/StudentMagicLinkService.cs
+++ b/backend/CoachOS.Infrastructure/Identity/StudentMagicLinkService.cs
@@ -61,28 +61,15 @@ public class StudentMagicLinkService(
     public async Task<Result<StudentAuthResponseDto>> RedeemAsync(string rawToken, CancellationToken ct = default)
     {
         var tokenHash = Sha256Hex(rawToken);
-        var entity = await repo.GetByTokenHashAsync(tokenHash, ct);
 
+        // Atomisch consumeren voorkomt dat twee parallelle requests dezelfde token
+        // beide accepteren (race-condition tussen check en mark-used).
+        var entity = await repo.TryConsumeAsync(tokenHash, DateTime.UtcNow, ct);
         if (entity is null)
         {
-            logger.LogWarning("Magic-link redeem: onbekende token");
+            logger.LogWarning("Magic-link redeem: onbekende, verlopen of al gebruikte token");
             return Result<StudentAuthResponseDto>.Fail("Ongeldige of verlopen link");
         }
-
-        if (entity.UsedAt is not null)
-        {
-            logger.LogWarning("Magic-link redeem: al gebruikt (Id {Id})", entity.Id);
-            return Result<StudentAuthResponseDto>.Fail("Ongeldige of verlopen link");
-        }
-
-        if (entity.ExpiresAt < DateTime.UtcNow)
-        {
-            logger.LogWarning("Magic-link redeem: verlopen (Id {Id})", entity.Id);
-            return Result<StudentAuthResponseDto>.Fail("Ongeldige of verlopen link");
-        }
-
-        entity.UsedAt = DateTime.UtcNow;
-        await repo.SaveChangesAsync(ct);
 
         (var jwt, var expiresAt) = tokenService.GenerateStudentToken(entity.Email);
 

--- a/backend/CoachOS.Infrastructure/Identity/TrainerService.cs
+++ b/backend/CoachOS.Infrastructure/Identity/TrainerService.cs
@@ -126,16 +126,30 @@ public class TrainerService(
         if (user.InviteTokenExpiry is null || user.InviteTokenExpiry < DateTime.UtcNow)
             return Result<AuthResponseDto>.Fail("Uitnodigingslink is verlopen");
 
+        // Hele accept-flow in één transactie: password reset, user activation
+        // en membership activation moeten atomair gebeuren. Zonder transactie
+        // kon een fout halverwege een account met nieuw wachtwoord maar
+        // inactieve membership achterlaten.
+        await using var tx = await context.Database.BeginTransactionAsync(ct);
+
         var resetToken = await userManager.GeneratePasswordResetTokenAsync(user);
         var result = await userManager.ResetPasswordAsync(user, resetToken, password);
         if (!result.Succeeded)
+        {
+            await tx.RollbackAsync(ct);
             return Result<AuthResponseDto>.Fail(result.Errors.Select(e => e.Description));
+        }
 
         user.IsActive = true;
         user.InviteToken = null;
         user.InviteTokenExpiry = null;
         user.UpdatedAt = DateTime.UtcNow;
-        await userManager.UpdateAsync(user);
+        var updateResult = await userManager.UpdateAsync(user);
+        if (!updateResult.Succeeded)
+        {
+            await tx.RollbackAsync(ct);
+            return Result<AuthResponseDto>.Fail(updateResult.Errors.Select(e => e.Description));
+        }
 
         // Activeer het bijbehorende (pending) membership. Een nieuwe user heeft
         // bij acceptatie per definitie exact één pending membership — we checken
@@ -147,15 +161,22 @@ public class TrainerService(
             .ToListAsync(ct);
 
         if (pendings.Count == 0)
+        {
+            await tx.RollbackAsync(ct);
             return Result<AuthResponseDto>.Fail("Geen openstaande uitnodiging gevonden");
+        }
 
         if (pendings.Count > 1)
+        {
+            await tx.RollbackAsync(ct);
             return Result<AuthResponseDto>.Fail("Meerdere openstaande uitnodigingen gevonden — neem contact op met support");
+        }
 
         var pending = pendings[0];
 
         pending.IsActive = true;
         await context.SaveChangesAsync(ct);
+        await tx.CommitAsync(ct);
 
         (var jwtToken, var expiresAt) = tokenService.GenerateToken(user, pending);
 

--- a/backend/CoachOS.Infrastructure/Identity/UserLookupService.cs
+++ b/backend/CoachOS.Infrastructure/Identity/UserLookupService.cs
@@ -55,6 +55,15 @@ public class UserLookupService(ApplicationDbContext context) : IUserLookupServic
                 && m.IsActive, ct);
     }
 
+    public async Task<int> CountActiveTrainersAsync(Guid organizationId, CancellationToken ct = default)
+    {
+        return await context.OrganizationMemberships
+            .AsNoTracking()
+            .CountAsync(m => m.OrganizationId == organizationId
+                && m.Role == UserRole.Trainer
+                && m.IsActive, ct);
+    }
+
     public async Task<Dictionary<Guid, (string FullName, string Email)>> GetUserNamesAndEmailsByIdsAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
     {
         var idList = ids.ToList();

--- a/backend/CoachOS.Infrastructure/Repositories/AssignmentConfirmationTokenRepository.cs
+++ b/backend/CoachOS.Infrastructure/Repositories/AssignmentConfirmationTokenRepository.cs
@@ -1,4 +1,5 @@
 using CoachOS.Domain.Entities;
+using CoachOS.Domain.Enums;
 using CoachOS.Domain.Interfaces;
 using CoachOS.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
@@ -39,5 +40,19 @@ public class AssignmentConfirmationTokenRepository(ApplicationDbContext context)
     public async Task SaveChangesAsync(CancellationToken ct = default)
     {
         await context.SaveChangesAsync(ct);
+    }
+
+    public async Task<bool> TryClaimResponseAsync(
+        Guid tokenId,
+        ConfirmationResponse target,
+        DateTime now,
+        CancellationToken ct = default)
+    {
+        var affected = await context.AssignmentConfirmationTokens
+            .Where(t => t.Id == tokenId && t.Response == ConfirmationResponse.Pending)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(t => t.Response, target)
+                .SetProperty(t => t.RespondedAt, now), ct);
+        return affected == 1;
     }
 }

--- a/backend/CoachOS.Infrastructure/Repositories/MagicLinkTokenRepository.cs
+++ b/backend/CoachOS.Infrastructure/Repositories/MagicLinkTokenRepository.cs
@@ -15,4 +15,21 @@ public class MagicLinkTokenRepository(ApplicationDbContext context) : IMagicLink
 
     public async Task SaveChangesAsync(CancellationToken ct = default)
         => await context.SaveChangesAsync(ct);
+
+    public async Task<MagicLinkToken?> TryConsumeAsync(string tokenHash, DateTime now, CancellationToken ct = default)
+    {
+        // Atomic claim via conditional UPDATE. PostgreSQL lockt de row tijdens UPDATE —
+        // twee parallelle requests zien er exact één met affected=1, de andere 0.
+        var affected = await context.MagicLinkTokens
+            .Where(t => t.TokenHash == tokenHash && t.UsedAt == null && t.ExpiresAt > now)
+            .ExecuteUpdateAsync(s => s.SetProperty(t => t.UsedAt, now), ct);
+
+        if (affected == 0)
+            return null;
+
+        // Tracked entities kunnen nu stale zijn; lees vers terug zonder tracking.
+        return await context.MagicLinkTokens
+            .AsNoTracking()
+            .FirstOrDefaultAsync(t => t.TokenHash == tokenHash, ct);
+    }
 }

--- a/frontend/app/(auth)/invite/[token]/page.tsx
+++ b/frontend/app/(auth)/invite/[token]/page.tsx
@@ -75,6 +75,7 @@ export default function InvitePage({
         lastName: response.lastName,
         organizationId: response.organizationId,
         role: response.role,
+        memberships: response.memberships,
       });
       router.push("/dashboard");
     } catch (error) {

--- a/frontend/app/(auth)/login/page.tsx
+++ b/frontend/app/(auth)/login/page.tsx
@@ -82,6 +82,7 @@ function LoginForm() {
         lastName: response.lastName,
         organizationId: response.organizationId,
         role: response.role,
+        memberships: response.memberships,
       });
       if (redirectTo) {
         router.push(redirectTo);

--- a/frontend/app/(auth)/register/page.tsx
+++ b/frontend/app/(auth)/register/page.tsx
@@ -102,6 +102,7 @@ export default function RegisterPage() {
         lastName: response.lastName,
         organizationId: response.organizationId,
         role: response.role,
+        memberships: response.memberships,
       });
       router.push("/dashboard");
     } catch (error) {

--- a/frontend/app/(dashboard)/layout.tsx
+++ b/frontend/app/(dashboard)/layout.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { DashboardSidebar } from "@/components/layouts/dashboard-sidebar";
 import { MobileBottomNav } from "@/components/layouts/dashboard-bottom-nav";
+import { OrgSwitcher } from "@/components/layouts/org-switcher";
 import { getAuthUser, isAuthenticated, type AuthUser } from "@/lib/auth";
 
 const ROLE_LABELS: Record<string, string> = {
@@ -48,6 +49,12 @@ export default function DashboardLayout({
             Tennis &amp; Padel Platform
           </p>
           <div className="flex items-center gap-3">
+            {user.memberships && user.memberships.length > 1 && (
+              <OrgSwitcher
+                memberships={user.memberships}
+                activeOrganizationId={user.organizationId}
+              />
+            )}
             <div className="text-right">
               <p className="text-sm font-semibold text-gray-800 leading-none">{fullName}</p>
               <p className="text-xs text-gray-400 mt-0.5">{roleLabel}</p>

--- a/frontend/components/layouts/org-switcher.tsx
+++ b/frontend/components/layouts/org-switcher.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { ChevronsUpDown, Check } from "lucide-react";
+
+import { switchOrganization } from "@/lib/api/auth";
+import {
+  getAuthUser,
+  setAuthUser,
+  setToken,
+  type OrganizationMembershipInfo,
+} from "@/lib/auth";
+
+interface OrgSwitcherProps {
+  memberships: OrganizationMembershipInfo[];
+  activeOrganizationId: string | null | undefined;
+}
+
+export function OrgSwitcher({ memberships, activeOrganizationId }: OrgSwitcherProps) {
+  const t = useTranslations("orgSwitcher");
+  const router = useRouter();
+  const [isOpen, setIsOpen] = useState(false);
+  const [isSwitching, setIsSwitching] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+    if (isOpen) document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen]);
+
+  const active = memberships.find((m) => m.organizationId === activeOrganizationId) ?? memberships[0];
+
+  async function handleSelect(organizationId: string) {
+    if (organizationId === activeOrganizationId || isSwitching) {
+      setIsOpen(false);
+      return;
+    }
+    setIsSwitching(true);
+    try {
+      const response = await switchOrganization(organizationId);
+      setToken(response.token);
+      const user = getAuthUser();
+      setAuthUser({
+        userId: response.userId,
+        email: response.email,
+        firstName: response.firstName ?? user?.firstName,
+        lastName: response.lastName ?? user?.lastName,
+        organizationId: response.organizationId,
+        role: response.role,
+        memberships: response.memberships,
+      });
+      setIsOpen(false);
+      // Refresh zodat alle server state opnieuw opgehaald wordt met nieuwe tenant.
+      router.refresh();
+      window.location.reload();
+    } catch {
+      setIsSwitching(false);
+    }
+  }
+
+  if (memberships.length <= 1 || !active) return null;
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setIsOpen((v) => !v)}
+        disabled={isSwitching}
+        className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-gray-200 bg-white hover:bg-gray-50 transition-colors cursor-pointer disabled:opacity-50"
+      >
+        <span className="text-sm font-medium text-gray-800 max-w-[160px] truncate">
+          {active.organizationName}
+        </span>
+        <ChevronsUpDown className="w-3.5 h-3.5 text-gray-400" />
+      </button>
+
+      {isOpen && (
+        <div className="absolute right-0 mt-2 w-64 rounded-lg border border-gray-100 bg-white shadow-lg z-50 overflow-hidden">
+          <div className="px-3 py-2 text-xs font-semibold text-gray-400 uppercase tracking-wider border-b border-gray-100">
+            {t("title")}
+          </div>
+          <ul className="py-1 max-h-80 overflow-y-auto">
+            {memberships.map((m) => (
+              <li key={m.organizationId}>
+                <button
+                  type="button"
+                  onClick={() => handleSelect(m.organizationId)}
+                  className="w-full flex items-center justify-between gap-2 px-3 py-2 text-left hover:bg-gray-50 transition-colors cursor-pointer"
+                >
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-gray-800 truncate">
+                      {m.organizationName}
+                    </p>
+                    <p className="text-xs text-gray-400">{m.role}</p>
+                  </div>
+                  {m.organizationId === active.organizationId && (
+                    <Check className="w-4 h-4 text-tennis-green shrink-0" />
+                  )}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/lib/api/auth.ts
+++ b/frontend/lib/api/auth.ts
@@ -1,5 +1,12 @@
 import apiClient from '@/lib/api-client';
 
+export interface OrganizationMembershipInfo {
+  organizationId: string;
+  organizationName: string;
+  role: string;
+  isActive: boolean;
+}
+
 export interface AuthResponse {
   token: string;
   expiresAt: string;
@@ -9,6 +16,7 @@ export interface AuthResponse {
   lastName: string;
   organizationId: string | null;
   role: string;
+  memberships: OrganizationMembershipInfo[];
 }
 
 export interface RegisterStudentRequest {
@@ -43,6 +51,18 @@ export async function register(request: RegisterRequest): Promise<AuthResponse> 
 
 export async function registerStudent(request: RegisterStudentRequest): Promise<AuthResponse> {
   const { data } = await apiClient.post<AuthResponse>('/auth/register-student', request);
+  return data;
+}
+
+export async function getMyMemberships(): Promise<OrganizationMembershipInfo[]> {
+  const { data } = await apiClient.get<OrganizationMembershipInfo[]>('/auth/memberships');
+  return data;
+}
+
+export async function switchOrganization(organizationId: string): Promise<AuthResponse> {
+  const { data } = await apiClient.post<AuthResponse>('/auth/switch-organization', {
+    organizationId,
+  });
   return data;
 }
 

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -2,6 +2,13 @@ const TOKEN_KEY = 'token';
 const USER_KEY = 'auth_user';
 const AUTH_COOKIE = 'has_token';
 
+export interface OrganizationMembershipInfo {
+  organizationId: string;
+  organizationName: string;
+  role: string;
+  isActive: boolean;
+}
+
 export interface AuthUser {
   userId?: string;
   email: string;
@@ -9,6 +16,7 @@ export interface AuthUser {
   lastName?: string;
   organizationId?: string | null;
   role: string;
+  memberships?: OrganizationMembershipInfo[];
 }
 
 export function isStudent(): boolean {

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -9,6 +9,9 @@
     "create": "Aanmaken",
     "search": "Zoeken"
   },
+  "orgSwitcher": {
+    "title": "Wissel van organisatie"
+  },
   "navigation": {
     "dashboard": "Dashboard",
     "courts": "Banen",


### PR DESCRIPTION
## Summary

Follow-ups on the multi-tenant PR (#41) — closes a few race conditions flagged during the post-merge sweep and adds the missing FE for the two new auth endpoints.

**Backend race/transaction fixes**
- Magic-link redeem is now an atomic conditional UPDATE (hash + UsedAt IS NULL + not expired). Two parallel redeems can no longer both succeed.
- Student confirmation Confirm/Decline atomically flip Response Pending → Confirmed/Declined via ExecuteUpdate. A double-click on "Bevestigen" can no longer create a duplicate Payment row.
- Trainer accept-invite is wrapped in a transaction — password reset + user activation + membership activation now succeed or fail as a unit.

**Frontend: organisation switcher**
- New OrgSwitcher dropdown in the dashboard topbar. Shows only when the user has 2+ memberships.
- Calls POST /auth/switch-organization, stores the new JWT + membership list, reloads so all queries refetch under the new tenant.
- AuthUser, AuthResponse, and the login/register/invite-accept flows now persist the memberships array.

## Test plan

- [x] `dotnet build CoachOS.slnx` green
- [x] `dotnet test CoachOS.slnx` — 95/95 passing
- [x] `tsc --noEmit` on frontend — clean
- [x] `./reset.sh` end-to-end green
- [ ] Manual: invite same trainer email into a second org, log in, confirm the switcher appears and switches tenant
- [ ] Manual: double-click confirm in the student portal — second click should show "al verwerkt"