### PR TITLE
fix(backend): race conditions, tenant leaks, email XSS, and flow bugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,13 @@ cd backend
 dotnet ef migrations add <Name> --project CoachOS.Infrastructure --startup-project CoachOS.API
 dotnet ef database update --project CoachOS.Infrastructure --startup-project CoachOS.API
 
+# Reset & seed (definitieve E2E-check — destructief, wipet DB volume)
+cd backend
+bash Scripts/reset-db.sh --no-frontend         # docker compose down -v + up -d (zonder frontend)
+# Wacht tot /health 200 terugkeert, dan:
+bash Scripts/seed-demo-data.sh                 # registreert admin, creëert clubs/series/enrollments/planning
+# PowerShell equivalenten: Scripts/reset-db.ps1 en Scripts/seed-demo-data.ps1
+
 # Add shadcn component
 cd frontend && bunx shadcn add <component>
 ```
@@ -102,6 +109,40 @@ PostgreSQL via EF Core. All entities use `Guid` PKs. `ApplicationUser` configura
 ## Seed Scripts
 
 When modifying the database schema (entities, migrations), API request/response DTOs, validation rules, or business logic that affects public endpoints — **always check and update the seed scripts** in `backend/Scripts/` (`seed-demo-data.sh`, `setup.sh`) to match. The seed scripts call the API to create demo data, so any contract change will silently break seeding.
+
+## Reset-flow: definitieve E2E-check
+
+Een feature is **pas "done" als een volledige reset + seed end-to-end groen loopt.** Unit tests bewijzen correctheid van losse services — reset bewijst dat migrations, contracts, validators, transactie-volgorde en seed-script allemaal met elkaar kloppen.
+
+**Standaard flow na significant backend werk:**
+
+```bash
+cd backend
+bash Scripts/reset-db.sh --no-frontend      # 1. Wipet postgres_data volume + rebuild containers
+# Wacht tot http://localhost:5142/health → 200 (API draait auto-migrate bij startup)
+bash Scripts/seed-demo-data.sh              # 2. API-based seed: registratie, clubs, series, enrollments, planning
+```
+
+**Wat de reset test:**
+
+- Migrations passen toe op lege DB (geen drift)
+- `RegisterAsync` / admin creatie werkt (1e org)
+- `TennisClub` / `LessonSerie` CRUD + validators
+- Trainer-uitnodiging + membership flow
+- Enrollment submit (solo + group) inclusief capacity/duplicate checks in transactie
+- Planning generatie + scheduling algorithm
+- `ConfirmScheduleAsync` incl. token creatie + email rendering
+- Tweede org + multi-org membership (`org-switcher`)
+
+**Wanneer reset verplicht:**
+
+- EF migratie toegevoegd
+- Contract van publieke endpoint (enrollment, magic-link, confirmation) gewijzigd
+- Transactieboundary of service-orchestratie aangepast
+- Email template tokens / `MjmlTemplateRenderer` gewijzigd
+- Before opening PR met backend changes
+
+Als seed faalt: drift in DTO/validator/migratie → eerst `seed-data.json` + `seed-demo-data.py` bijwerken, niet de validators verzwakken.
 
 ## Working Style
 

--- a/backend/CoachOS.Application/Enrollments/EnrollmentService.cs
+++ b/backend/CoachOS.Application/Enrollments/EnrollmentService.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using System.Text.Json;
 using CoachOS.Application.Enrollments.DTOs;
 using CoachOS.Application.LessonSerie.DTOs;
@@ -200,22 +201,10 @@ public class EnrollmentService(
             return Result<Guid>.Fail(
                 new Error(ErrorCodes.Validation, "De inschrijvingsdeadline is verstreken."));
 
-        // 3. Capacity check (accounts for group size)
-        if (series.MaxRegistrations.HasValue)
-        {
-            var activeCount = await enrollmentRepo.CountActiveBySeriesAsync(lessonSeriesId, ct);
-            var groupSize = request.EnrollmentType == "group" && request.GroupMembers is not null
-                ? request.GroupMembers.Count + 1
-                : 1;
-            if (activeCount + groupSize > series.MaxRegistrations.Value)
-                return Result<Guid>.Fail(
-                    new Error(ErrorCodes.Conflict, "Deze lessenreeks is volzet."));
-        }
-
-        // 4. Load enrollment form with fields (may be null)
+        // 3. Load enrollment form with fields (may be null)
         var form = await enrollmentFormRepo.GetBySeriesIdReadOnlyAsync(lessonSeriesId, ct);
 
-        // 5. Validate form responses against actual form fields
+        // 4. Validate form responses against actual form fields (pre-transaction: cheap, no race risk)
         if (form is not null)
         {
             var formFieldIds = form.Fields.Select(f => f.Id).ToHashSet();
@@ -244,17 +233,37 @@ public class EnrollmentService(
             }
         }
 
-        // 6. Duplicate check
-        var isDuplicate = await enrollmentRepo.IsDuplicateAsync(lessonSeriesId, request.StudentEmail, ct);
-        if (isDuplicate)
-            return Result<Guid>.Fail(
-                new Error(ErrorCodes.Conflict, "Je bent al ingeschreven voor deze lessenreeks."));
+        var groupSize = request.EnrollmentType == "group" && request.GroupMembers is not null
+            ? request.GroupMembers.Count + 1
+            : 1;
 
-        // 7. Begin transaction for multi-step enrollment
+        // 5. Begin SERIALIZABLE transaction: capacity + duplicate checks moeten ATOMIC zijn
+        //    met de insert, anders kunnen twee parallelle submitters beide de check passeren
+        //    en samen MaxRegistrations overschrijden of een duplicate email creëren.
         Enrollment enrollment;
-        await enrollmentRepo.BeginTransactionAsync(ct);
+        await enrollmentRepo.BeginTransactionAsync(IsolationLevel.Serializable, ct);
         try
         {
+            // 6. Capacity check INSIDE transaction (accounts for group size)
+            if (series.MaxRegistrations.HasValue)
+            {
+                var activeCount = await enrollmentRepo.CountActiveBySeriesAsync(lessonSeriesId, ct);
+                if (activeCount + groupSize > series.MaxRegistrations.Value)
+                {
+                    await enrollmentRepo.RollbackTransactionAsync(ct);
+                    return Result<Guid>.Fail(
+                        new Error(ErrorCodes.Conflict, "Deze lessenreeks is volzet."));
+                }
+            }
+
+            // 7. Duplicate check INSIDE transaction (case-insensitive)
+            var isDuplicate = await enrollmentRepo.IsDuplicateAsync(lessonSeriesId, request.StudentEmail, ct);
+            if (isDuplicate)
+            {
+                await enrollmentRepo.RollbackTransactionAsync(ct);
+                return Result<Guid>.Fail(
+                    new Error(ErrorCodes.Conflict, "Je bent al ingeschreven voor deze lessenreeks."));
+            }
 
         // 8. Create enrollment
         enrollment = new()
@@ -291,13 +300,15 @@ public class EnrollmentService(
         {
             var existingGroupCount = await enrollmentGroupRepo.CountBySeriesAsync(
                 lessonSeriesId, series.OrganizationId, ct);
-            var groupLetter = (char)('A' + existingGroupCount);
+            // Naming: A–Z voor eerste 26 groepen, dan AA, AB, …, BA, BB, … zodat de namen
+            // leesbaar blijven (geen non-printables zoals [ of \ bij 'A'+26).
+            var groupName = BuildGroupName(existingGroupCount);
 
             EnrollmentGroup group = new()
             {
                 OrganizationId = series.OrganizationId,
                 LessonSerieId = series.Id,
-                Name = $"Groep {groupLetter}",
+                Name = $"Groep {groupName}",
                 LeaderEnrollmentId = enrollment.Id,
             };
 
@@ -395,6 +406,30 @@ public class EnrollmentService(
                 trainerInfo?.FullName ?? string.Empty,
                 ct);
 
+            // Bij groepsinschrijving ook elk groepslid een bevestigingsmail sturen —
+            // anders weten alleen de leider dat de inschrijving gelukt is.
+            if (request.EnrollmentType == "group" && request.GroupMembers is { Count: > 0 })
+            {
+                foreach (var member in request.GroupMembers)
+                {
+                    try
+                    {
+                        await emailService.SendEnrollmentConfirmationAsync(
+                            member.StudentEmail,
+                            member.StudentName,
+                            series.Name,
+                            trainerInfo?.FullName ?? string.Empty,
+                            ct);
+                    }
+                    catch (Exception memberEx)
+                    {
+                        logger.LogError(memberEx,
+                            "E-mail naar groepslid {Email} mislukt voor inschrijving {EnrollmentId}",
+                            member.StudentEmail, enrollment.Id);
+                    }
+                }
+            }
+
             if (trainerInfo.HasValue)
             {
                 await emailService.SendEnrollmentNotificationToTrainerAsync(
@@ -480,6 +515,20 @@ public class EnrollmentService(
             .ToList();
 
         return Result<List<EnrollmentWithPreferencesDto>>.Ok(dtos);
+    }
+
+    private static string BuildGroupName(int index)
+    {
+        // 0 → A, 25 → Z, 26 → AA, 27 → AB, …, 701 → ZZ, 702 → AAA, enz.
+        var name = string.Empty;
+        var n = index;
+        while (true)
+        {
+            name = (char)('A' + n % 26) + name;
+            n = n / 26 - 1;
+            if (n < 0) break;
+        }
+        return name;
     }
 
     private List<string>? DeserializeOptions(string? json)

--- a/backend/CoachOS.Application/LessonSerie/LessonSerieService.cs
+++ b/backend/CoachOS.Application/LessonSerie/LessonSerieService.cs
@@ -79,6 +79,12 @@ public class LessonSerieService(
         if (!clubExists)
             return Result<Guid>.Fail(new Error(ErrorCodes.NotFound, "Tennisclub niet gevonden."));
 
+        var trainerIds = request.WeeklyTemplate.Select(t => t.TrainerId)
+            .Concat(request.Lessons.Select(l => l.TrainerId));
+        var trainerError = await ValidateTrainerIdsAsync(trainerIds, organizationId, ct);
+        if (trainerError is not null)
+            return Result<Guid>.Fail(trainerError);
+
         var series = mapper.ToLessonSerie(request, organizationId);
 
         foreach (var templateRequest in request.WeeklyTemplate)
@@ -163,11 +169,38 @@ public class LessonSerieService(
         if (series is null)
             return Result<Guid>.Fail(new Error(ErrorCodes.NotFound, "LessonSerie niet gevonden."));
 
+        if (request.TrainerId.HasValue)
+        {
+            var isValid = await userLookup.IsActiveTrainerAsync(request.TrainerId.Value, organizationId, ct);
+            if (!isValid)
+                return Result<Guid>.Fail(
+                    new Error(ErrorCodes.Validation, "Deze trainer behoort niet tot deze organisatie."));
+        }
+
         var lesson = mapper.ToLesson(request, series);
         await lessonRepo.AddAsync(lesson, ct);
         await lessonRepo.SaveChangesAsync(ct);
 
         return Result<Guid>.Ok(lesson.Id);
+    }
+
+    private async Task<Error?> ValidateTrainerIdsAsync(
+        IEnumerable<Guid?> trainerIds, Guid organizationId, CancellationToken ct)
+    {
+        var distinctIds = trainerIds
+            .Where(id => id.HasValue)
+            .Select(id => id!.Value)
+            .Distinct()
+            .ToList();
+
+        foreach (var trainerId in distinctIds)
+        {
+            var isValid = await userLookup.IsActiveTrainerAsync(trainerId, organizationId, ct);
+            if (!isValid)
+                return new Error(ErrorCodes.Validation,
+                    "Een of meer geselecteerde trainers behoren niet tot deze organisatie.");
+        }
+        return null;
     }
 
     public async Task<Result> DeleteLessonAsync(

--- a/backend/CoachOS.Application/Planning/ConfirmationOrchestrationService.cs
+++ b/backend/CoachOS.Application/Planning/ConfirmationOrchestrationService.cs
@@ -67,9 +67,23 @@ public class ConfirmationOrchestrationService(
             emailsToSend.Add((recipient, assignment, rawToken));
         }
 
-        await tokenRepo.AddRangeAsync(tokens, ct);
-        series.PlanningStatus = PlanningStatus.AwaitingConfirmation;
-        await lessonSeriesRepo.SaveChangesAsync(ct);
+        // Atomic: status-flips + token-inserts moeten samen committen. Zonder transactie
+        // kan een crash tussen de twee saves de reeks in Planning laten met zwevende tokens
+        // (of tokens zonder status-flip op de assignments).
+        await lessonSeriesRepo.BeginTransactionAsync(ct);
+        try
+        {
+            await tokenRepo.AddRangeAsync(tokens, ct);
+            series.PlanningStatus = PlanningStatus.AwaitingConfirmation;
+            await lessonSeriesRepo.SaveChangesAsync(ct);
+            await lessonSeriesRepo.CommitTransactionAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            await lessonSeriesRepo.RollbackTransactionAsync(ct);
+            logger.LogError(ex, "Planning-bevestiging commit mislukt voor reeks {SeriesId}", seriesId);
+            return Result<bool>.Fail(new Error(ErrorCodes.Unexpected, "Planning kon niet bevestigd worden. Probeer het opnieuw."));
+        }
 
         foreach (var (recipient, assignment, rawToken) in emailsToSend)
         {

--- a/backend/CoachOS.Application/StudentConfirmation/StudentConfirmationService.cs
+++ b/backend/CoachOS.Application/StudentConfirmation/StudentConfirmationService.cs
@@ -160,6 +160,20 @@ public class StudentConfirmationService(
                 new Error(ErrorCodes.Validation,
                     $"Tijdslot heeft geen plaats meer ({currentCount}/{targetSlot.MaxStudents})."));
 
+        // Atomisch de token-response flippen VOOR het aanmaken van assignment/payment.
+        // Zonder deze claim kunnen twee parallelle "pick alternative" requests beide de
+        // capacity check passeren en elk een nieuwe ScheduleAssignment + Payment aanmaken
+        // → dubbele booking + dubbele betaling.
+        var claimed = await tokenRepo.TryTransitionResponseAsync(
+            token.Id,
+            ConfirmationResponse.Declined,
+            ConfirmationResponse.Confirmed,
+            DateTime.UtcNow,
+            ct);
+        if (!claimed)
+            return Result<ConfirmResultDto>.Fail(
+                new Error(ErrorCodes.Validation, "Deze bevestiging is al verwerkt."));
+
         // Create new assignment in Confirmed state directly (user is committing).
         ScheduleAssignment newAssignment = new()
         {
@@ -185,9 +199,6 @@ public class StudentConfirmationService(
             Description = $"Cash (alternatief) — {series.Name}",
         };
         await paymentRepo.AddAsync(payment, ct);
-
-        token.Response = ConfirmationResponse.Confirmed;
-        token.RespondedAt = DateTime.UtcNow;
 
         ConfirmEnrollmentStatuses(oldAssignment);
         await paymentRepo.SaveChangesAsync(ct);

--- a/backend/CoachOS.Application/Students/StudentLessonsService.cs
+++ b/backend/CoachOS.Application/Students/StudentLessonsService.cs
@@ -44,10 +44,14 @@ public class StudentLessonsService(
 
         var trainerNames = await userLookup.GetUserNamesByIdsAsync(trainerIds, ct);
 
+        // Betaling wordt opgeslagen tegen de leader (solo: eigen enrollment, group: LeaderEnrollmentId).
+        // Lookup moet dezelfde leader gebruiken — anders krijgen niet-leader-members PaymentStatus=null.
         var enrollmentIds = assignments
-            .SelectMany(a => a.EnrollmentGroupId.HasValue && a.EnrollmentGroup is not null
-                ? a.EnrollmentGroup.Members.Select(m => m.Id)
-                : a.EnrollmentId.HasValue ? [a.EnrollmentId.Value] : Enumerable.Empty<Guid>())
+            .Select(a => a.EnrollmentGroupId.HasValue && a.EnrollmentGroup is not null
+                ? a.EnrollmentGroup.LeaderEnrollmentId
+                : a.EnrollmentId)
+            .Where(id => id.HasValue)
+            .Select(id => id!.Value)
             .Distinct()
             .ToList();
 
@@ -63,9 +67,10 @@ public class StudentLessonsService(
                 var isGroup = a.EnrollmentGroupId.HasValue && a.EnrollmentGroup is not null;
                 var size = isGroup ? a.EnrollmentGroup!.Members.Count : 1;
 
-                // Use the current student's own enrollment id for payment lookup when possible.
-                Guid? enrId = a.EnrollmentId
-                    ?? a.EnrollmentGroup?.Members.FirstOrDefault()?.Id;
+                // Payment is altijd tegen de leader geboekt — gebruik LeaderEnrollmentId voor groups.
+                Guid? enrId = a.EnrollmentGroupId.HasValue && a.EnrollmentGroup is not null
+                    ? a.EnrollmentGroup.LeaderEnrollmentId
+                    : a.EnrollmentId;
 
                 return new StudentLessonDto
                 {

--- a/backend/CoachOS.Domain/Interfaces/IAssignmentConfirmationTokenRepository.cs
+++ b/backend/CoachOS.Domain/Interfaces/IAssignmentConfirmationTokenRepository.cs
@@ -25,4 +25,16 @@ public interface IAssignmentConfirmationTokenRepository
         Domain.Enums.ConfirmationResponse target,
         DateTime now,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Atomisch de Response van een specifieke waarde (<paramref name="from"/>) naar
+    /// <paramref name="to"/> flippen. Gebruikt voor "pick alternative" waar de
+    /// transition Declined → Confirmed is. Retourneert true bij één rij affected.
+    /// </summary>
+    Task<bool> TryTransitionResponseAsync(
+        Guid tokenId,
+        Domain.Enums.ConfirmationResponse from,
+        Domain.Enums.ConfirmationResponse to,
+        DateTime now,
+        CancellationToken ct = default);
 }

--- a/backend/CoachOS.Domain/Interfaces/IEnrollmentRepository.cs
+++ b/backend/CoachOS.Domain/Interfaces/IEnrollmentRepository.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using CoachOS.Domain.Entities;
 using CoachOS.Domain.Enums;
 
@@ -25,6 +26,8 @@ public interface IEnrollmentRepository
     Task SaveChangesAsync(CancellationToken ct = default);
 
     Task BeginTransactionAsync(CancellationToken ct = default);
+
+    Task BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken ct = default);
 
     Task CommitTransactionAsync(CancellationToken ct = default);
 

--- a/backend/CoachOS.Domain/Interfaces/ILessonSerieRepository.cs
+++ b/backend/CoachOS.Domain/Interfaces/ILessonSerieRepository.cs
@@ -14,4 +14,8 @@ public interface ILessonSerieRepository
     Task<bool> ExistsAsync(Guid id, Guid organizationId, CancellationToken ct = default);
     Task<bool> AnyByTennisClubAsync(Guid tennisClubId, CancellationToken ct = default);
     Task SaveChangesAsync(CancellationToken ct = default);
+
+    Task BeginTransactionAsync(CancellationToken ct = default);
+    Task CommitTransactionAsync(CancellationToken ct = default);
+    Task RollbackTransactionAsync(CancellationToken ct = default);
 }

--- a/backend/CoachOS.Infrastructure/Email/EmailService.cs
+++ b/backend/CoachOS.Infrastructure/Email/EmailService.cs
@@ -90,11 +90,13 @@ public class EmailService(
         if (responses.Count > 0)
         {
             responsesLabel = "Antwoorden formulier";
+            // Elke waarde HTML-encoden: FieldLabel en Value zijn student-invoer en kunnen
+            // anders HTML/script bevatten dat in de trainer-inbox gerenderd wordt.
             var rows = string.Join("",
                 responses.Select(r =>
                     $"<div style=\"padding:8px 0;border-bottom:1px solid #f3f4f6\">" +
-                    $"<span style=\"color:#6b7280;display:inline-block;width:40%\">{r.FieldLabel}</span>" +
-                    $"<span style=\"color:#111827\">{r.Value}</span></div>"));
+                    $"<span style=\"color:#6b7280;display:inline-block;width:40%\">{WebUtility.HtmlEncode(r.FieldLabel)}</span>" +
+                    $"<span style=\"color:#111827\">{WebUtility.HtmlEncode(r.Value)}</span></div>"));
             responsesHtml = rows;
         }
         else
@@ -103,6 +105,8 @@ public class EmailService(
             responsesHtml = string.Empty;
         }
 
+        // responsesHtml is door ons zelf gebouwde HTML (reeds geëncodeerde waarden) →
+        // gebruik "raw:" prefix zodat de renderer niet nogmaals encodeert.
         var html = renderer.Render("enrollment-notification-trainer", new Dictionary<string, string>
         {
             ["trainerName"] = trainerName,
@@ -110,7 +114,7 @@ public class EmailService(
             ["studentEmail"] = studentEmail,
             ["seriesName"] = seriesName,
             ["responsesLabel"] = responsesLabel,
-            ["responsesHtml"] = responsesHtml,
+            ["raw:responsesHtml"] = responsesHtml,
             ["year"] = DateTime.UtcNow.Year.ToString(),
         });
         await SendAsync(trainerEmail, trainerName,

--- a/backend/CoachOS.Infrastructure/Email/MjmlTemplateRenderer.cs
+++ b/backend/CoachOS.Infrastructure/Email/MjmlTemplateRenderer.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using Mjml.Net;
@@ -58,9 +59,22 @@ public class MjmlTemplateRenderer : IMjmlTemplateRenderer
         if (!_compiled.TryGetValue(templateName, out var html))
             throw new KeyNotFoundException($"MJML template '{templateName}' not loaded. Available: {string.Join(", ", _compiled.Keys)}");
 
+        // HTML-encode elke token-value om XSS/HTML-injectie via student-invoer te blokkeren
+        // (student names, form responses, trainer names, enz). Keys met prefix "raw:" worden
+        // NIET geëncodeerd — gebruik alleen voor door de app gegenereerde HTML (tabelrijen e.d.).
         var sb = new StringBuilder(html);
         foreach (var kv in tokens)
-            sb.Replace("{{" + kv.Key + "}}", kv.Value);
+        {
+            if (kv.Key.StartsWith("raw:", StringComparison.Ordinal))
+            {
+                var realKey = kv.Key.Substring(4);
+                sb.Replace("{{" + realKey + "}}", kv.Value);
+            }
+            else
+            {
+                sb.Replace("{{" + kv.Key + "}}", WebUtility.HtmlEncode(kv.Value));
+            }
+        }
         return sb.ToString();
     }
 }

--- a/backend/CoachOS.Infrastructure/Repositories/AssignmentConfirmationTokenRepository.cs
+++ b/backend/CoachOS.Infrastructure/Repositories/AssignmentConfirmationTokenRepository.cs
@@ -55,4 +55,19 @@ public class AssignmentConfirmationTokenRepository(ApplicationDbContext context)
                 .SetProperty(t => t.RespondedAt, now), ct);
         return affected == 1;
     }
+
+    public async Task<bool> TryTransitionResponseAsync(
+        Guid tokenId,
+        ConfirmationResponse from,
+        ConfirmationResponse to,
+        DateTime now,
+        CancellationToken ct = default)
+    {
+        var affected = await context.AssignmentConfirmationTokens
+            .Where(t => t.Id == tokenId && t.Response == from)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(t => t.Response, to)
+                .SetProperty(t => t.RespondedAt, now), ct);
+        return affected == 1;
+    }
 }

--- a/backend/CoachOS.Infrastructure/Repositories/EnrollmentRepository.cs
+++ b/backend/CoachOS.Infrastructure/Repositories/EnrollmentRepository.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using CoachOS.Domain.Entities;
 using CoachOS.Domain.Enums;
 using CoachOS.Domain.Interfaces;
@@ -30,11 +31,12 @@ public class EnrollmentRepository(ApplicationDbContext context) : IEnrollmentRep
     public async Task<bool> IsDuplicateAsync(
         Guid lessonSeriesId, string studentEmail, CancellationToken ct = default)
     {
+        var normalized = studentEmail.Trim().ToLower();
         return await context.Enrollments
             .AsNoTracking()
             .AnyAsync(e =>
                 e.LessonSerieId == lessonSeriesId &&
-                e.StudentEmail == studentEmail &&
+                e.StudentEmail.ToLower() == normalized &&
                 (e.Status == EnrollmentStatus.Confirmed || e.Status == EnrollmentStatus.Pending), ct);
     }
 
@@ -74,6 +76,11 @@ public class EnrollmentRepository(ApplicationDbContext context) : IEnrollmentRep
     public async Task BeginTransactionAsync(CancellationToken ct = default)
     {
         await context.Database.BeginTransactionAsync(ct);
+    }
+
+    public async Task BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken ct = default)
+    {
+        await context.Database.BeginTransactionAsync(isolationLevel, ct);
     }
 
     public async Task CommitTransactionAsync(CancellationToken ct = default)

--- a/backend/CoachOS.Infrastructure/Repositories/LessonSerieRepository.cs
+++ b/backend/CoachOS.Infrastructure/Repositories/LessonSerieRepository.cs
@@ -60,6 +60,23 @@ public class LessonSerieRepository(ApplicationDbContext context) : ILessonSerieR
         await context.SaveChangesAsync(ct);
     }
 
+    public async Task BeginTransactionAsync(CancellationToken ct = default)
+    {
+        await context.Database.BeginTransactionAsync(ct);
+    }
+
+    public async Task CommitTransactionAsync(CancellationToken ct = default)
+    {
+        if (context.Database.CurrentTransaction is not null)
+            await context.Database.CommitTransactionAsync(ct);
+    }
+
+    public async Task RollbackTransactionAsync(CancellationToken ct = default)
+    {
+        if (context.Database.CurrentTransaction is not null)
+            await context.Database.RollbackTransactionAsync(ct);
+    }
+
     public async Task<LessonSerie?> GetByIdPublicAsync(Guid id, CancellationToken ct = default)
     {
         return await context.LessonSeries

--- a/backend/CoachOS.Tests/Services/LessonSerieServiceTests.cs
+++ b/backend/CoachOS.Tests/Services/LessonSerieServiceTests.cs
@@ -39,6 +39,12 @@ public class LessonSerieServiceTests
             _tennisClubRepo.Object,
             _userLookup.Object,
             _mapper);
+
+        // Default: alle trainers valideren als actief binnen de org. Individuele tests
+        // kunnen dit overriden voor negatieve scenarios (invalid/cross-tenant trainer).
+        _userLookup
+            .Setup(u => u.IsActiveTrainerAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────
@@ -341,7 +347,7 @@ public class LessonSerieServiceTests
     }
 
     [Test]
-    public async Task CreateAsync_ReturnsNotFound_WhenTrainerInvalid()
+    public async Task CreateAsync_ReturnsValidation_WhenTrainerBelongsToAnotherOrg()
     {
         CreateLessonSerieRequest request = new()
         {
@@ -367,14 +373,16 @@ public class LessonSerieServiceTests
             .Setup(r => r.ExistsAsync(ClubId, OrgId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
-        _lessonSeriesRepo
-            .Setup(r => r.AddAsync(It.IsAny<LessonSerie>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+        // Simuleer cross-tenant trainer: IsActiveTrainerAsync geeft false voor deze org.
+        _userLookup
+            .Setup(u => u.IsActiveTrainerAsync(TrainerId, OrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
 
         var result = await _service.CreateAsync(OrgId, request);
 
-        // Trainer validation no longer happens at series level — series creates successfully
-        result.IsSuccess.Should().BeTrue();
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainSingle(e => e.Code == ErrorCodes.Validation);
+        _lessonSeriesRepo.Verify(r => r.AddAsync(It.IsAny<LessonSerie>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     // ── UpdateAsync ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Ten backend fixes after a three-agent code review (dotnet-reviewer, security-auditor, code-analyzer). All server-side, no frontend impact.

## Critical fixes (money / tenant isolation / XSS)
- **Atomic token claim in `PickAlternativeAsync`** — parallel clicks no longer create double assignments + double Payment rows.
- **Enrollment capacity + duplicate race** — checks moved inside a SERIALIZABLE transaction; `MaxRegistrations` can no longer be exceeded by concurrent submitters.
- **Case-insensitive duplicate email check** — prevents `A@x.com` / `a@x.com` double enrollment.
- **TrainerId cross-tenant validation** — `LessonSerieService.Create` / `AddLesson` now verify every TrainerId belongs to the caller's org.
- **HTML injection in emails** — `MjmlTemplateRenderer` HTML-encodes token values by default; trainer notification rows also encoded.

## High-priority fixes (data integrity / UX)
- `ConfirmScheduleAsync` wrapped in transaction (token inserts + status flip atomic).
- Group members now get their own confirmation email.
- `PaymentStatus` for group members looked up via `LeaderEnrollmentId`.
- Group naming no longer collides after 26 groups (A-Z, AA, AB, ...).

## Docs
- `CLAUDE.md`: reset+seed commands + "Reset-flow" section describing definitive E2E check.

## Test plan
- [x] `dotnet build CoachOS.slnx` succeeds
- [x] `dotnet test CoachOS.slnx` — 95/95 passing
- [x] `bash Scripts/reset-db.sh --no-frontend` + `bash Scripts/seed-demo-data.sh` — full seed runs green end-to-end (admin register, clubs, trainer invites, 3 series, 10 enrollments, Zomerlessen planning generate+confirm, second org + multi-org membership)
- [ ] Manual smoke: public enrollment form (new error codes on race) — no FE change needed yet, backend returns Dutch messages already in `messages/nl.json`

## Out of scope (documented plan for follow-up PRs)
- PR 3: Scheduling correctness (SchedulingAlgorithm overcommit, TryFinalizeSeries with Declined tokens)
- PR 4: Email robustness / outbox (ResendConfirmation tokens-before-email)
- PR 5: Security hardening (magic-link rate limit per-email, unused repo method cleanup)
- PR 6: Repository conventions (missing orgId params, HashToken dedup)
- PR 7: DB CHECK constraints on `ScheduleAssignment`