### PR TITLE
fix(planning): don't finalize series while participants have declined without replacement

### DIFF
--- a/backend/CoachOS.Application/Planning/ConfirmationOrchestrationService.cs
+++ b/backend/CoachOS.Application/Planning/ConfirmationOrchestrationService.cs
@@ -277,7 +277,17 @@ public class ConfirmationOrchestrationService(
         var allTokens = await tokenRepo.GetBySeriesAsync(seriesId, organizationId, ct);
         var stillPending = allTokens.Any(t => t.Response == ConfirmationResponse.Pending
             && t.ExpiresAt >= DateTime.UtcNow);
-        if (!stillPending && series.PlanningStatus == PlanningStatus.AwaitingConfirmation)
+
+        // Alleen finaliseren als élke deelnemer minstens één Confirmed toewijzing heeft.
+        // Een Declined zonder vervanging is een gat in de planning — admin moet eerst
+        // resolven voordat de reeks naar Scheduled mag.
+        var allAssignments = await scheduleAssignmentRepo.GetBySeriesAsync(seriesId, organizationId, ct);
+        var everyParticipantConfirmed = allAssignments
+            .GroupBy(a => a.EnrollmentGroupId ?? a.EnrollmentId ?? Guid.Empty)
+            .Where(g => g.Key != Guid.Empty)
+            .All(g => g.Any(a => a.Status == ScheduleAssignmentStatus.Confirmed));
+
+        if (!stillPending && everyParticipantConfirmed && series.PlanningStatus == PlanningStatus.AwaitingConfirmation)
         {
             series.PlanningStatus = PlanningStatus.Scheduled;
             await lessonSeriesRepo.SaveChangesAsync(ct);

--- a/backend/CoachOS.Application/StudentConfirmation/StudentConfirmationService.cs
+++ b/backend/CoachOS.Application/StudentConfirmation/StudentConfirmationService.cs
@@ -305,9 +305,30 @@ public class StudentConfirmationService(
         var tokens = await tokenRepo.GetBySeriesAsync(seriesId, organizationId, ct);
         if (tokens.Count == 0) return;
 
+        // Stap 1: zijn er nog openstaande tokens? (student heeft nog niet gereageerd en is niet verlopen)
         var anyPending = tokens.Any(t => t.Response == ConfirmationResponse.Pending
             && t.ExpiresAt >= DateTime.UtcNow);
         if (anyPending) return;
+
+        // Stap 2: elke enrollment/group moet minstens één Confirmed assignment hebben.
+        // Een Declined zonder Confirmed vervanging betekent dat een student een gat
+        // heeft in de planning — de reeks mag dan NIET naar Scheduled gaan, want dan
+        // lijkt het alsof iedereen is ingedeeld. Admin moet eerst handmatig oplossen
+        // (resend, admin-confirm, of extra pick-alternative).
+        var assignments = await assignmentRepo.GetBySeriesAsync(seriesId, organizationId, ct);
+        var byParticipant = assignments
+            .GroupBy(a => a.EnrollmentGroupId ?? a.EnrollmentId ?? Guid.Empty)
+            .Where(g => g.Key != Guid.Empty);
+
+        var allParticipantsConfirmed = byParticipant.All(g =>
+            g.Any(a => a.Status == ScheduleAssignmentStatus.Confirmed));
+        if (!allParticipantsConfirmed)
+        {
+            logger.LogInformation(
+                "Reeks {SeriesId} niet gefinaliseerd: nog deelnemers zonder bevestigde toewijzing.",
+                seriesId);
+            return;
+        }
 
         var series = await seriesRepo.GetByIdAsync(seriesId, organizationId, ct);
         if (series is null) return;


### PR DESCRIPTION
## Summary
Fix planning finalization so a series is only marked **Scheduled** when every participant actually has a confirmed slot. Previously a student who declined without picking an alternative was treated as "done" and the series got locked in a partially-scheduled state.

## Changes
- `StudentConfirmationService.TryFinalizeSeriesAsync` — groups assignments by participant (`EnrollmentGroupId ?? EnrollmentId`) and requires at least one `Confirmed` per participant before flipping the series status.
- `ConfirmationOrchestrationService.AdminConfirmAssignmentAsync` — same check added to the admin confirm path.

## Behavior
- Every student confirmed (or picked alternative) → series → `Scheduled` (unchanged happy path)
- Mix of Confirmed + Declined-with-replacement → series → `Scheduled` (pick-alternative keeps working)
- Any participant has only Declined / expired tokens → series stays `AwaitingConfirmation` so admin can intervene

## Out of scope
Dropped from this PR after investigation:
- **SchedulingAlgorithm silent overcommit** — reviewed: locked capacity is clamped to 0 which correctly blocks the algorithm from adding more; `BuildConflicts` already surfaces `oversubscribed` slots post-hoc, so the concern was already handled.
- **Stale Declined assignment after PickAlternative** — cosmetic only now that the finalize check groups by participant; left for a future UI-cleanup PR.

## Test plan
- [x] `dotnet build` + `dotnet test` — 95/95 passing
- [x] `reset-db.sh --no-frontend` + full rebuild (`docker compose up -d --build backend`) + `seed-demo-data.sh` — end-to-end green with Zomerlessen 2026 planning generate+confirm
- [ ] Manual: decline a single-person proposal, don't pick alternative, verify series stays `AwaitingConfirmation` (admin UI)