### PR TITLE
fix(confirmation): resolve 3 review findings in series finalize flow

### DIFF
--- a/backend/CoachOS.Application/Planning/ConfirmationOrchestrationService.cs
+++ b/backend/CoachOS.Application/Planning/ConfirmationOrchestrationService.cs
@@ -274,20 +274,28 @@ public class ConfirmationOrchestrationService(
 
         await paymentRepo.SaveChangesAsync(ct);
 
-        var allTokens = await tokenRepo.GetBySeriesAsync(seriesId, organizationId, ct);
+        // No-tracking: concurrent requests kunnen tokens via ExecuteUpdateAsync hebben
+        // gemuteerd zonder dat onze change tracker dat weet. Tracking-read zou dan via
+        // identity resolution stale in-memory Response=Pending teruggeven → stillPending
+        // zou onterecht true zijn en de finaliseer-stap zou gemist worden.
+        var allTokens = await tokenRepo.GetBySeriesAsNoTrackingAsync(seriesId, organizationId, ct);
         var stillPending = allTokens.Any(t => t.Response == ConfirmationResponse.Pending
             && t.ExpiresAt >= DateTime.UtcNow);
 
-        // Alleen finaliseren als élke deelnemer minstens één Confirmed toewijzing heeft.
-        // Een Declined zonder vervanging is een gat in de planning — admin moet eerst
-        // resolven voordat de reeks naar Scheduled mag.
+        // Alleen finaliseren als élke deelnemer "afgerond" is.
+        // - Confirmed toewijzing: OK.
+        // - Geen Declined en geen Confirmed (alleen AwaitingConfirmation + expired token):
+        //   niet-responder, per MVP-contract geldt dat als "handled" — blokkeert niet.
+        // - Declined zonder Confirmed vervanging: WÉL blokkerend — dat is een gat in de
+        //   planning, admin moet eerst resenden / admin-confirmen / pick-alternative.
         var allAssignments = await scheduleAssignmentRepo.GetBySeriesAsync(seriesId, organizationId, ct);
-        var everyParticipantConfirmed = allAssignments
+        var hasBlockingParticipant = allAssignments
             .GroupBy(a => a.EnrollmentGroupId ?? a.EnrollmentId ?? Guid.Empty)
             .Where(g => g.Key != Guid.Empty)
-            .All(g => g.Any(a => a.Status == ScheduleAssignmentStatus.Confirmed));
+            .Any(g => g.Any(a => a.Status == ScheduleAssignmentStatus.Declined)
+                && g.All(a => a.Status != ScheduleAssignmentStatus.Confirmed));
 
-        if (!stillPending && everyParticipantConfirmed && series.PlanningStatus == PlanningStatus.AwaitingConfirmation)
+        if (!stillPending && !hasBlockingParticipant && series.PlanningStatus == PlanningStatus.AwaitingConfirmation)
         {
             series.PlanningStatus = PlanningStatus.Scheduled;
             await lessonSeriesRepo.SaveChangesAsync(ct);

--- a/backend/CoachOS.Application/StudentConfirmation/StudentConfirmationService.cs
+++ b/backend/CoachOS.Application/StudentConfirmation/StudentConfirmationService.cs
@@ -302,7 +302,11 @@ public class StudentConfirmationService(
     private async Task TryFinalizeSeriesAsync(
         Guid seriesId, Guid organizationId, CancellationToken ct)
     {
-        var tokens = await tokenRepo.GetBySeriesAsync(seriesId, organizationId, ct);
+        // No-tracking: TryClaim/TryTransition muteren via ExecuteUpdateAsync (bypasst
+        // change tracker). Een tracking-query zou via identity resolution de zojuist
+        // geclaimde token teruggeven met stale in-memory Response=Pending, waardoor
+        // de anyPending-guard hieronder altijd true zou zijn op het student-pad.
+        var tokens = await tokenRepo.GetBySeriesAsNoTrackingAsync(seriesId, organizationId, ct);
         if (tokens.Count == 0) return;
 
         // Stap 1: zijn er nog openstaande tokens? (student heeft nog niet gereageerd en is niet verlopen)
@@ -310,22 +314,27 @@ public class StudentConfirmationService(
             && t.ExpiresAt >= DateTime.UtcNow);
         if (anyPending) return;
 
-        // Stap 2: elke enrollment/group moet minstens één Confirmed assignment hebben.
-        // Een Declined zonder Confirmed vervanging betekent dat een student een gat
-        // heeft in de planning — de reeks mag dan NIET naar Scheduled gaan, want dan
-        // lijkt het alsof iedereen is ingedeeld. Admin moet eerst handmatig oplossen
-        // (resend, admin-confirm, of extra pick-alternative).
+        // Stap 2: zijn er deelnemers met een "gat" in de planning?
+        // Een gat = een Declined toewijzing zonder Confirmed vervanging. Dat mag niet
+        // stilletjes Scheduled worden, want dan lijkt die student ingedeeld terwijl
+        // hij feitelijk nergens staat. Admin moet eerst resolven.
+        //
+        // Let op — expired non-responders blokkeren NIET: hun token is verlopen
+        // (Stap 1 filtert Pending+expired weg) en hun toewijzing blijft Awaiting-
+        // Confirmation. Per MVP-contract (docs/student-confirmation-cash-mvp.md:163)
+        // tellen die als "handled" zodat één niet-reagerende student de reeks niet
+        // permanent tegenhoudt.
         var assignments = await assignmentRepo.GetBySeriesAsync(seriesId, organizationId, ct);
-        var byParticipant = assignments
+        var hasBlockingParticipant = assignments
             .GroupBy(a => a.EnrollmentGroupId ?? a.EnrollmentId ?? Guid.Empty)
-            .Where(g => g.Key != Guid.Empty);
+            .Where(g => g.Key != Guid.Empty)
+            .Any(g => g.Any(a => a.Status == ScheduleAssignmentStatus.Declined)
+                && g.All(a => a.Status != ScheduleAssignmentStatus.Confirmed));
 
-        var allParticipantsConfirmed = byParticipant.All(g =>
-            g.Any(a => a.Status == ScheduleAssignmentStatus.Confirmed));
-        if (!allParticipantsConfirmed)
+        if (hasBlockingParticipant)
         {
             logger.LogInformation(
-                "Reeks {SeriesId} niet gefinaliseerd: nog deelnemers zonder bevestigde toewijzing.",
+                "Reeks {SeriesId} niet gefinaliseerd: deelnemer met Declined zonder vervanging.",
                 seriesId);
             return;
         }

--- a/backend/CoachOS.Domain/Interfaces/IAssignmentConfirmationTokenRepository.cs
+++ b/backend/CoachOS.Domain/Interfaces/IAssignmentConfirmationTokenRepository.cs
@@ -10,6 +10,15 @@ public interface IAssignmentConfirmationTokenRepository
     Task<List<AssignmentConfirmationToken>> GetBySeriesAsync(
         Guid lessonSerieId, Guid organizationId, CancellationToken ct = default);
 
+    /// <summary>
+    /// No-tracking variant voor read-only paden die moeten lezen nadat
+    /// <see cref="TryClaimResponseAsync"/> of <see cref="TryTransitionResponseAsync"/>
+    /// via <c>ExecuteUpdateAsync</c> de DB heeft gemuteerd. De tracking-versie zou
+    /// via identity resolution een stale in-memory instance teruggeven.
+    /// </summary>
+    Task<List<AssignmentConfirmationToken>> GetBySeriesAsNoTrackingAsync(
+        Guid lessonSerieId, Guid organizationId, CancellationToken ct = default);
+
     Task AddRangeAsync(
         IEnumerable<AssignmentConfirmationToken> tokens, CancellationToken ct = default);
 

--- a/backend/CoachOS.Infrastructure/Repositories/AssignmentConfirmationTokenRepository.cs
+++ b/backend/CoachOS.Infrastructure/Repositories/AssignmentConfirmationTokenRepository.cs
@@ -31,6 +31,19 @@ public class AssignmentConfirmationTokenRepository(ApplicationDbContext context)
             .ToListAsync(ct);
     }
 
+    public async Task<List<AssignmentConfirmationToken>> GetBySeriesAsNoTrackingAsync(
+        Guid lessonSerieId, Guid organizationId, CancellationToken ct = default)
+    {
+        return await context.AssignmentConfirmationTokens
+            .AsNoTracking()
+            .Include(t => t.ScheduleAssignment).ThenInclude(a => a.Enrollment)
+            .Include(t => t.ScheduleAssignment).ThenInclude(a => a.EnrollmentGroup!).ThenInclude(g => g.Members)
+            .Include(t => t.Enrollment)
+            .Where(t => t.OrganizationId == organizationId
+                && t.ScheduleAssignment.LessonSerieId == lessonSerieId)
+            .ToListAsync(ct);
+    }
+
     public async Task AddRangeAsync(
         IEnumerable<AssignmentConfirmationToken> tokens, CancellationToken ct = default)
     {

--- a/backend/CoachOS.Tests/Services/StudentConfirmationServiceTests.cs
+++ b/backend/CoachOS.Tests/Services/StudentConfirmationServiceTests.cs
@@ -1,0 +1,374 @@
+using System.Security.Cryptography;
+using System.Text;
+using CoachOS.Application.StudentConfirmation;
+using CoachOS.Application.StudentConfirmation.DTOs;
+using CoachOS.Domain.Entities;
+using CoachOS.Domain.Enums;
+using CoachOS.Domain.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+
+namespace CoachOS.Tests.Services;
+
+/// <summary>
+/// Regression tests voor de staleness-bug in <see cref="StudentConfirmationService.TryFinalizeSeriesAsync"/>.
+/// <para>
+/// Context: <see cref="IAssignmentConfirmationTokenRepository.TryClaimResponseAsync"/> muteert de DB via
+/// <c>ExecuteUpdateAsync</c>, wat de EF change tracker bypasst. Een opvolgende tracking-read via
+/// <c>GetBySeriesAsync</c> zou via identity resolution een stale in-memory token teruggeven
+/// (Response=Pending), waardoor de anyPending-guard de serie nooit zou finaliseren op het student-pad.
+/// </para>
+/// </summary>
+[TestFixture]
+public class StudentConfirmationServiceTests
+{
+    private Mock<IAssignmentConfirmationTokenRepository> _tokenRepo = null!;
+    private Mock<IScheduleAssignmentRepository> _assignmentRepo = null!;
+    private Mock<ILessonSerieRepository> _seriesRepo = null!;
+    private Mock<IPaymentRepository> _paymentRepo = null!;
+    private Mock<ILogger<StudentConfirmationService>> _logger = null!;
+    private StudentConfirmationService _sut = null!;
+
+    private static readonly Guid OrgId = Guid.NewGuid();
+    private static readonly Guid SeriesId = Guid.NewGuid();
+    private static readonly Guid SlotId = Guid.NewGuid();
+
+    [SetUp]
+    public void SetUp()
+    {
+        _tokenRepo = new Mock<IAssignmentConfirmationTokenRepository>();
+        _assignmentRepo = new Mock<IScheduleAssignmentRepository>();
+        _seriesRepo = new Mock<ILessonSerieRepository>();
+        _paymentRepo = new Mock<IPaymentRepository>();
+        _logger = new Mock<ILogger<StudentConfirmationService>>();
+
+        _sut = new StudentConfirmationService(
+            _tokenRepo.Object,
+            _assignmentRepo.Object,
+            _seriesRepo.Object,
+            _paymentRepo.Object,
+            _logger.Object);
+    }
+
+    [Test]
+    public async Task ConfirmAsync_LastPendingConfirmation_FlipsSeriesToScheduled_UsingNoTrackingRead()
+    {
+        // Arrange: soloenrollment, 1 token, student is de laatste bevestiger.
+        const string rawToken = "demo-raw-token";
+        string hash = HashToken(rawToken);
+
+        LessonSerie series = PlanningServiceTests.BuildSeries(withSlots: true, SeriesId, OrgId, SlotId);
+        series.PlanningStatus = PlanningStatus.AwaitingConfirmation;
+        series.Price = 80m;
+
+        Enrollment enrollment = PlanningServiceTests.BuildEnrollment("Alice", OrgId, SeriesId);
+
+        ScheduleAssignment assignment = new()
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = OrgId,
+            LessonSerieId = SeriesId,
+            WeeklyTemplateEntryId = SlotId,
+            EnrollmentId = enrollment.Id,
+            Enrollment = enrollment,
+            Status = ScheduleAssignmentStatus.AwaitingConfirmation,
+        };
+
+        AssignmentConfirmationToken token = new()
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = OrgId,
+            ScheduleAssignmentId = assignment.Id,
+            EnrollmentId = enrollment.Id,
+            TokenHash = hash,
+            Response = ConfirmationResponse.Pending,
+            ExpiresAt = DateTime.UtcNow.AddHours(72),
+            ScheduleAssignment = assignment,
+            Enrollment = enrollment,
+        };
+
+        _tokenRepo.Setup(r => r.GetByTokenHashAsync(hash, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(token);
+
+        _seriesRepo.Setup(r => r.GetByIdAsync(SeriesId, OrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(series);
+
+        _tokenRepo.Setup(r => r.TryClaimResponseAsync(
+                token.Id, ConfirmationResponse.Confirmed, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        // Bewust: tracking-variant levert STALE data (Pending). Als de service deze gebruikt,
+        // zou anyPending true zijn en zou de serie in AwaitingConfirmation blijven → test faalt.
+        _tokenRepo.Setup(r => r.GetBySeriesAsync(SeriesId, OrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AssignmentConfirmationToken>
+            {
+                StaleCopyOf(token), // Response nog Pending (stale)
+            });
+
+        // No-tracking variant levert FRESH data (Confirmed) — zoals DB werkelijk is na ExecuteUpdate.
+        _tokenRepo.Setup(r => r.GetBySeriesAsNoTrackingAsync(SeriesId, OrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AssignmentConfirmationToken>
+            {
+                FreshCopyOf(token, ConfirmationResponse.Confirmed),
+            });
+
+        assignment.Status = ScheduleAssignmentStatus.Confirmed;
+        _assignmentRepo.Setup(r => r.GetBySeriesAsync(SeriesId, OrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ScheduleAssignment> { assignment });
+
+        // Act
+        var result = await _sut.ConfirmAsync(
+            rawToken,
+            new ConfirmRequest { PaymentMethod = (int)PaymentMethod.Cash },
+            CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        series.PlanningStatus.Should().Be(PlanningStatus.Scheduled,
+            "de serie moet finaliseren wanneer de no-tracking read aantoont dat alles bevestigd is");
+
+        _tokenRepo.Verify(
+            r => r.GetBySeriesAsNoTrackingAsync(SeriesId, OrgId, It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce,
+            "TryFinalizeSeriesAsync MOET de no-tracking variant gebruiken om de stale-read bug te vermijden");
+    }
+
+    [Test]
+    public async Task ConfirmAsync_ParticipantWithDeclinedWithoutReplacement_DoesNotFinalize()
+    {
+        // Arrange: 2 deelnemers. Eén confirmed, één declined zonder vervanging.
+        // Reeks mag NIET naar Scheduled flippen ondanks dat er geen pending tokens meer zijn.
+        const string rawToken = "demo-raw-token-2";
+        string hash = HashToken(rawToken);
+
+        LessonSerie series = PlanningServiceTests.BuildSeries(withSlots: true, SeriesId, OrgId, SlotId);
+        series.PlanningStatus = PlanningStatus.AwaitingConfirmation;
+        series.Price = 80m;
+
+        Enrollment alice = PlanningServiceTests.BuildEnrollment("Alice", OrgId, SeriesId);
+        Enrollment bob = PlanningServiceTests.BuildEnrollment("Bob", OrgId, SeriesId);
+
+        ScheduleAssignment aliceAssignment = new()
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = OrgId,
+            LessonSerieId = SeriesId,
+            WeeklyTemplateEntryId = SlotId,
+            EnrollmentId = alice.Id,
+            Enrollment = alice,
+            Status = ScheduleAssignmentStatus.AwaitingConfirmation,
+        };
+        ScheduleAssignment bobAssignment = new()
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = OrgId,
+            LessonSerieId = SeriesId,
+            WeeklyTemplateEntryId = SlotId,
+            EnrollmentId = bob.Id,
+            Enrollment = bob,
+            Status = ScheduleAssignmentStatus.Declined, // Bob heeft eerder gedeclined zonder pick-alternative
+        };
+
+        AssignmentConfirmationToken aliceToken = new()
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = OrgId,
+            ScheduleAssignmentId = aliceAssignment.Id,
+            EnrollmentId = alice.Id,
+            TokenHash = hash,
+            Response = ConfirmationResponse.Pending,
+            ExpiresAt = DateTime.UtcNow.AddHours(72),
+            ScheduleAssignment = aliceAssignment,
+            Enrollment = alice,
+        };
+        AssignmentConfirmationToken bobToken = new()
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = OrgId,
+            ScheduleAssignmentId = bobAssignment.Id,
+            EnrollmentId = bob.Id,
+            TokenHash = "bob-hash",
+            Response = ConfirmationResponse.Declined,
+            ExpiresAt = DateTime.UtcNow.AddHours(72),
+            ScheduleAssignment = bobAssignment,
+            Enrollment = bob,
+        };
+
+        _tokenRepo.Setup(r => r.GetByTokenHashAsync(hash, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(aliceToken);
+
+        _seriesRepo.Setup(r => r.GetByIdAsync(SeriesId, OrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(series);
+
+        _tokenRepo.Setup(r => r.TryClaimResponseAsync(
+                aliceToken.Id, ConfirmationResponse.Confirmed, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        aliceAssignment.Status = ScheduleAssignmentStatus.Confirmed;
+
+        _tokenRepo.Setup(r => r.GetBySeriesAsNoTrackingAsync(SeriesId, OrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AssignmentConfirmationToken>
+            {
+                FreshCopyOf(aliceToken, ConfirmationResponse.Confirmed),
+                FreshCopyOf(bobToken, ConfirmationResponse.Declined),
+            });
+
+        _assignmentRepo.Setup(r => r.GetBySeriesAsync(SeriesId, OrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ScheduleAssignment> { aliceAssignment, bobAssignment });
+
+        // Act
+        var result = await _sut.ConfirmAsync(
+            rawToken,
+            new ConfirmRequest { PaymentMethod = (int)PaymentMethod.Cash },
+            CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        series.PlanningStatus.Should().Be(PlanningStatus.AwaitingConfirmation,
+            "Bob heeft een Declined zonder Confirmed vervanging — de reeks is niet rond.");
+    }
+
+    [Test]
+    public async Task ConfirmAsync_ExpiredNonResponder_DoesNotBlockFinalize()
+    {
+        // Regression guard voor docs/student-confirmation-cash-mvp.md:163:
+        // "Expired tokens count as handled — so one non-responder doesn't block the series forever."
+        //
+        // Scenario: Alice bevestigt als laatste actieve deelnemer. Charlie is een niet-
+        // responder: zijn token is verlopen (Pending + ExpiresAt in het verleden) en zijn
+        // ScheduleAssignment staat nog op AwaitingConfirmation (er is geen sweeper).
+        // De reeks MOET alsnog naar Scheduled flippen.
+        const string rawToken = "demo-raw-token-3";
+        string hash = HashToken(rawToken);
+
+        LessonSerie series = PlanningServiceTests.BuildSeries(withSlots: true, SeriesId, OrgId, SlotId);
+        series.PlanningStatus = PlanningStatus.AwaitingConfirmation;
+        series.Price = 80m;
+
+        Enrollment alice = PlanningServiceTests.BuildEnrollment("Alice", OrgId, SeriesId);
+        Enrollment charlie = PlanningServiceTests.BuildEnrollment("Charlie", OrgId, SeriesId);
+
+        ScheduleAssignment aliceAssignment = new()
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = OrgId,
+            LessonSerieId = SeriesId,
+            WeeklyTemplateEntryId = SlotId,
+            EnrollmentId = alice.Id,
+            Enrollment = alice,
+            Status = ScheduleAssignmentStatus.AwaitingConfirmation,
+        };
+        ScheduleAssignment charlieAssignment = new()
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = OrgId,
+            LessonSerieId = SeriesId,
+            WeeklyTemplateEntryId = SlotId,
+            EnrollmentId = charlie.Id,
+            Enrollment = charlie,
+            Status = ScheduleAssignmentStatus.AwaitingConfirmation, // non-responder blijft awaiting
+        };
+
+        AssignmentConfirmationToken aliceToken = new()
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = OrgId,
+            ScheduleAssignmentId = aliceAssignment.Id,
+            EnrollmentId = alice.Id,
+            TokenHash = hash,
+            Response = ConfirmationResponse.Pending,
+            ExpiresAt = DateTime.UtcNow.AddHours(72),
+            ScheduleAssignment = aliceAssignment,
+            Enrollment = alice,
+        };
+        AssignmentConfirmationToken charlieTokenExpired = new()
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = OrgId,
+            ScheduleAssignmentId = charlieAssignment.Id,
+            EnrollmentId = charlie.Id,
+            TokenHash = "charlie-hash",
+            Response = ConfirmationResponse.Pending,
+            ExpiresAt = DateTime.UtcNow.AddHours(-1), // verlopen — telt als "handled"
+            ScheduleAssignment = charlieAssignment,
+            Enrollment = charlie,
+        };
+
+        _tokenRepo.Setup(r => r.GetByTokenHashAsync(hash, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(aliceToken);
+
+        _seriesRepo.Setup(r => r.GetByIdAsync(SeriesId, OrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(series);
+
+        _tokenRepo.Setup(r => r.TryClaimResponseAsync(
+                aliceToken.Id, ConfirmationResponse.Confirmed, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        aliceAssignment.Status = ScheduleAssignmentStatus.Confirmed;
+
+        _tokenRepo.Setup(r => r.GetBySeriesAsNoTrackingAsync(SeriesId, OrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AssignmentConfirmationToken>
+            {
+                FreshCopyOf(aliceToken, ConfirmationResponse.Confirmed),
+                charlieTokenExpired, // Pending + expired
+            });
+
+        _assignmentRepo.Setup(r => r.GetBySeriesAsync(SeriesId, OrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ScheduleAssignment> { aliceAssignment, charlieAssignment });
+
+        // Act
+        var result = await _sut.ConfirmAsync(
+            rawToken,
+            new ConfirmRequest { PaymentMethod = (int)PaymentMethod.Cash },
+            CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        series.PlanningStatus.Should().Be(PlanningStatus.Scheduled,
+            "expired non-responders tellen als 'handled' per MVP-contract — zij mogen de reeks niet blokkeren");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static string HashToken(string raw)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(raw.Trim()));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+
+    private static AssignmentConfirmationToken StaleCopyOf(AssignmentConfirmationToken source)
+    {
+        return new AssignmentConfirmationToken
+        {
+            Id = source.Id,
+            OrganizationId = source.OrganizationId,
+            ScheduleAssignmentId = source.ScheduleAssignmentId,
+            EnrollmentId = source.EnrollmentId,
+            TokenHash = source.TokenHash,
+            Response = ConfirmationResponse.Pending, // stale in-memory waarde
+            ExpiresAt = source.ExpiresAt,
+            ScheduleAssignment = source.ScheduleAssignment,
+            Enrollment = source.Enrollment,
+        };
+    }
+
+    private static AssignmentConfirmationToken FreshCopyOf(
+        AssignmentConfirmationToken source, ConfirmationResponse freshResponse)
+    {
+        return new AssignmentConfirmationToken
+        {
+            Id = source.Id,
+            OrganizationId = source.OrganizationId,
+            ScheduleAssignmentId = source.ScheduleAssignmentId,
+            EnrollmentId = source.EnrollmentId,
+            TokenHash = source.TokenHash,
+            Response = freshResponse,
+            ExpiresAt = source.ExpiresAt,
+            RespondedAt = DateTime.UtcNow,
+            ScheduleAssignment = source.ScheduleAssignment,
+            Enrollment = source.Enrollment,
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Addresses 3 remote-review findings on the confirmation-finalize flow.

- **bug_002 (normal)** — stale EF-tracked token made the new Stap 2 guard unreachable on the student path. Added a `GetBySeriesAsNoTrackingAsync` repo method and use it in `StudentConfirmationService.TryFinalizeSeriesAsync`.
- **bug_003 (normal)** — new predicate was too strict ("every participant must have Confirmed"), which meant expired non-responders blocked the series forever, directly contradicting `docs/student-confirmation-cash-mvp.md:163`. Narrowed to "blocks iff participant has Declined AND no Confirmed". Applied in both `StudentConfirmationService` and `ConfirmationOrchestrationService` so the two finalize paths agree.
- **bug_005 (nit)** — admin path still used a tracking token re-read, creating an asymmetric staleness hazard under concurrent student confirms. Switched to `GetBySeriesAsNoTrackingAsync`.

## Test plan

- [x] `dotnet build CoachOS.slnx` — clean, 0 warnings
- [x] `dotnet test CoachOS.slnx` — 98/98 green (was 95 + 3 new regression tests)
- [x] New tests added in `StudentConfirmationServiceTests.cs`:
  - `ConfirmAsync_LastPendingConfirmation_FlipsSeriesToScheduled_UsingNoTrackingRead` — covers bug_002
  - `ConfirmAsync_ParticipantWithDeclinedWithoutReplacement_DoesNotFinalize` — guards the original "Declined without replacement" intent
  - `ConfirmAsync_ExpiredNonResponder_DoesNotBlockFinalize` — covers bug_003
- [ ] Manual reset + seed E2E if you want extra confidence (no schema/contract change, so not strictly required)