### PR TITLE
infra: hand TEM DNS records to Terraform; add Google Workspace MX

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -27,13 +27,14 @@ on:
   workflow_dispatch:
     inputs:
       action:
-        description: "plan or apply"
+        description: "plan, apply, or list-dns-records (one-off helper)"
         required: true
         default: "plan"
         type: choice
         options:
           - plan
           - apply
+          - list-dns-records
 
 permissions:
   contents: read
@@ -45,7 +46,33 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # One-off helper: dumps every DNS record with its UUID so we can build
+  # `import {}` blocks for records originally created by TEM autoconfig.
+  # Trigger via Actions UI → "Terraform — Plan & Apply" → Run workflow → action: list-dns-records.
+  # Remove this job once the imports are in main.
+  list-dns-records:
+    if: github.event_name == 'workflow_dispatch' && inputs.action == 'list-dns-records'
+    runs-on: ubuntu-latest
+    env:
+      SCW_ACCESS_KEY:              ${{ secrets.SCALEWAY_TF_ACCESS_KEY }}
+      SCW_SECRET_KEY:              ${{ secrets.SCALEWAY_TF_SECRET_KEY }}
+      SCW_DEFAULT_ORGANIZATION_ID: ${{ secrets.SCALEWAY_DEFAULT_ORGANIZATION_ID }}
+      SCW_DEFAULT_PROJECT_ID:      ${{ secrets.SCALEWAY_PROJECT_ID }}
+      SCW_DEFAULT_REGION:          fr-par
+      SCW_DEFAULT_ZONE:            fr-par-1
+    steps:
+      - name: Install scw CLI
+        run: |
+          curl -sLo scw https://github.com/scaleway/scaleway-cli/releases/latest/download/scaleway-cli_linux_amd64
+          chmod +x scw
+          sudo mv scw /usr/local/bin/scw
+          scw version
+
+      - name: List DNS records (JSON)
+        run: scw dns record list dns-zone=coach-os.be -o json
+
   plan:
+    if: github.event_name != 'workflow_dispatch' || inputs.action != 'list-dns-records'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -61,15 +61,12 @@ jobs:
       SCW_DEFAULT_REGION:          fr-par
       SCW_DEFAULT_ZONE:            fr-par-1
     steps:
-      - name: Install scw CLI
+      - name: List DNS records via Scaleway API
         run: |
-          curl -sLo scw https://github.com/scaleway/scaleway-cli/releases/latest/download/scaleway-cli_linux_amd64
-          chmod +x scw
-          sudo mv scw /usr/local/bin/scw
-          scw version
-
-      - name: List DNS records (JSON)
-        run: scw dns record list dns-zone=coach-os.be -o json
+          set -euo pipefail
+          curl -sS -H "X-Auth-Token: ${SCW_SECRET_KEY}" \
+            "https://api.scaleway.com/domain/v2beta1/dns-zones/coach-os.be/records?page_size=100" \
+            | jq '.records[] | {id, type, name, data, priority, ttl}'
 
   plan:
     if: github.event_name != 'workflow_dispatch' || inputs.action != 'list-dns-records'

--- a/infrastructure/terraform/dns.tf
+++ b/infrastructure/terraform/dns.tf
@@ -1,8 +1,9 @@
 # DNS records on Scaleway Domains for coach-os.be.
 # The domain itself must be registered/transferred at Scaleway before these apply.
 #
-# SPF/DKIM/DMARC records are NOT managed here — they're auto-created by
-# scaleway_tem_domain.coach_os (autoconfig = true). See main.tf.
+# SPF/DKIM/DMARC records for TEM are auto-created by scaleway_tem_domain.coach_os
+# (autoconfig = true). When we add Google Workspace SPF/DKIM/DMARC, we'll need to
+# disable autoconfig and manage all auth records here so Google + TEM can coexist.
 
 # Apex: coach-os.be → VPS public IP
 resource "scaleway_domain_record" "apex" {
@@ -20,4 +21,23 @@ resource "scaleway_domain_record" "www" {
   type     = "A"
   data     = scaleway_instance_ip.vps.address
   ttl      = 300
+}
+
+# ── Google Workspace MX record ───────────────────────────────────────────────
+# Mail for *@coach-os.be is delivered to Google Workspace mailboxes.
+# Modern Google setup uses a single MX (smtp.google.com) instead of the legacy
+# 5-record ASPMX.L.GOOGLE.COM setup; both are supported by Google.
+# TEM is send-only and does not need MX records, so no conflict with TEM.
+
+resource "scaleway_domain_record" "mx_google" {
+  dns_zone = var.domain_name
+  name     = ""
+  type     = "MX"
+  data     = "SMTP.GOOGLE.COM."
+  priority = 1
+  ttl      = 3600
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }

--- a/infrastructure/terraform/dns.tf
+++ b/infrastructure/terraform/dns.tf
@@ -1,9 +1,12 @@
 # DNS records on Scaleway Domains for coach-os.be.
 # The domain itself must be registered/transferred at Scaleway before these apply.
 #
-# SPF/DKIM/DMARC records for TEM are auto-created by scaleway_tem_domain.coach_os
-# (autoconfig = true). When we add Google Workspace SPF/DKIM/DMARC, we'll need to
-# disable autoconfig and manage all auth records here so Google + TEM can coexist.
+# Mail authentication records (SPF, DKIM, DMARC) and the TEM blackhole MX were
+# originally created by scaleway_tem_domain.coach_os with autoconfig = true.
+# Autoconfig is now disabled (see main.tf) so these records can co-host Google
+# Workspace SPF without TEM overwriting our merges. The 4 records were imported
+# via `import {}` blocks below — once apply succeeds, the import blocks can be
+# removed (kept here for traceability of where the values came from).
 
 # Apex: coach-os.be → VPS public IP
 resource "scaleway_domain_record" "apex" {
@@ -40,4 +43,79 @@ resource "scaleway_domain_record" "mx_google" {
   lifecycle {
     prevent_destroy = true
   }
+}
+
+# ── TEM blackhole MX (to be destroyed in follow-up PR) ───────────────────────
+# This record was created by TEM autoconfig to signal "this domain doesn't
+# accept mail". With Google Workspace as the inbox, it must be removed —
+# but Terraform requires importing first, then destroying in a separate plan.
+# Follow-up PR will delete the resource block (and import block) below.
+
+import {
+  to = scaleway_domain_record.tem_blackhole_mx
+  id = "coach-os.be/c13a636a-ce0e-4006-b010-514fd766fd7b"
+}
+
+resource "scaleway_domain_record" "tem_blackhole_mx" {
+  dns_zone = var.domain_name
+  name     = ""
+  type     = "MX"
+  data     = "blackhole.tem.scaleway.com."
+  priority = 0
+  ttl      = 3600
+}
+
+# ── SPF: combined Scaleway TEM + Google Workspace ────────────────────────────
+# include:_spf.tem.scaleway.com  → authorizes TEM for transactional email
+# include:_spf.google.com        → authorizes Gmail for outbound from @coach-os.be
+# ~all                           → softfail (Google-recommended for combined senders)
+
+import {
+  to = scaleway_domain_record.spf
+  id = "coach-os.be/8dc654ad-e20d-49fa-9316-e3107564a76d"
+}
+
+resource "scaleway_domain_record" "spf" {
+  dns_zone = var.domain_name
+  name     = ""
+  type     = "TXT"
+  data     = "v=spf1 include:_spf.tem.scaleway.com include:_spf.google.com ~all"
+  ttl      = 3600
+}
+
+# ── TEM DKIM ─────────────────────────────────────────────────────────────────
+# Selector UUID is assigned by Scaleway TEM when the domain is created.
+# The public key value below is what TEM auto-published; treat it as opaque.
+# If TEM ever rotates the key, look up the new value via the Scaleway API
+# and update both the name (selector) and data (public key) here.
+
+import {
+  to = scaleway_domain_record.tem_dkim
+  id = "coach-os.be/b57b69a7-cd66-417d-a474-650722debdbf"
+}
+
+resource "scaleway_domain_record" "tem_dkim" {
+  dns_zone = var.domain_name
+  name     = "9d341648-bcbf-496f-820b-968265d8394f._domainkey"
+  type     = "TXT"
+  data     = "v=DKIM1; h=sha256; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsFduwgevWYvpdVXuN9ivdc/URB8d2SRn62ErXTFIqG3sHUAwtVrby6LGeOtWK63wVE/PhgMh3xBk934++jHFwfs0AryTVaQYEtcPd4QESpuN6bif7o3hhwjB9XsxC7l56DjuqKexlTewA18S5/OGuKpFY7wCMSbnOUSQlAqqy9xXa24Scw0F/IJYxqnSwdKcc7kWoMX1ZBiIdsX/XRsaSlJGbaU8bFOKjTcNF7u6p5RRX43JyMitagww6fhPNxBkwo6G4AEY1YDorbc/Ijd/Z3t6GhjdD5pUbdS/LJsDVW/Ig97Q5dRnCCGNTYF2ih4aKjsInTCReHguCfB57VZGMwIDAQAB"
+  ttl      = 3600
+}
+
+# ── DMARC: monitoring-only policy ────────────────────────────────────────────
+# p=none means receivers don't quarantine/reject on SPF/DKIM failure — they
+# just report. Tighten to p=quarantine or p=reject once we add a rua= mailbox
+# and verify reports look healthy.
+
+import {
+  to = scaleway_domain_record.dmarc
+  id = "coach-os.be/fb08f5f5-340c-473c-a21e-37e58cc82e6c"
+}
+
+resource "scaleway_domain_record" "dmarc" {
+  dns_zone = var.domain_name
+  name     = "_dmarc"
+  type     = "TXT"
+  data     = "v=DMARC1; p=none"
+  ttl      = 3600
 }

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -113,15 +113,16 @@ resource "scaleway_rdb_privilege" "coach_os" {
 }
 
 # ── Transactional Email domain ───────────────────────────────────────────────
-# autoconfig = true lets Scaleway create and maintain the SPF/DKIM/DMARC
-# records directly in Scaleway Domains. We previously managed them manually
-# in dns.tf but the DKIM value drifted out of sync with TEM's expectations,
-# blocking domain verification.
+# autoconfig was enabled at bootstrap so Scaleway would auto-publish the
+# SPF/DKIM/DMARC + blackhole MX records. Now disabled because we co-host
+# Google Workspace SPF on the same TXT record, and TEM autoconfig would
+# overwrite our merged value. The auth records are now managed explicitly
+# in dns.tf (imported from the originals TEM created).
 
 resource "scaleway_tem_domain" "coach_os" {
   project_id = var.scw_project_id
   region     = var.scw_region
   name       = var.domain_name
   accept_tos = true
-  autoconfig = true
+  autoconfig = false
 }


### PR DESCRIPTION
Imports the 4 records TEM autoconfig created (blackhole MX, SPF,
  DKIM, DMARC), merges Google's SPF include into the existing TEM SPF record, adds the Google MX, and disables TEM autoconfig so it stops fighting us. Follow-up PR will destroy
  the blackhole MX so Google can actually receive mail.