### PR TITLE
fix(docker): reduce frontend image size with Next.js standalone output

### DIFF
--- a/.github/workflows/frontend-build-push.yml
+++ b/.github/workflows/frontend-build-push.yml
@@ -81,6 +81,7 @@ jobs:
             set -euo pipefail
             cd /app
             echo "$SCW_SECRET_KEY" | docker login rg.fr-par.scw.cloud -u nologin --password-stdin
+            docker image prune -f
             for i in 1 2 3; do
               if docker compose pull frontend; then break; fi
               [ $i -lt 3 ] && sleep 10 || exit 1

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -30,16 +30,13 @@ ENV HOSTNAME=0.0.0.0
 RUN addgroup --system --gid 1001 nodejs \
     && adduser --system --uid 1001 nextjs
 
-# Only copy what next start needs.
+# standalone/ contains server.js + minimal node_modules (no dev deps, no full tree).
+# static/ must be copied separately into the expected path.
 COPY --from=build --chown=nextjs:nodejs /app/public ./public
-COPY --from=build --chown=nextjs:nodejs /app/.next ./.next
-COPY --from=build --chown=nextjs:nodejs /app/node_modules ./node_modules
-COPY --from=build --chown=nextjs:nodejs /app/package.json ./package.json
-COPY --from=build --chown=nextjs:nodejs /app/next.config.ts ./next.config.ts
-COPY --from=build --chown=nextjs:nodejs /app/i18n ./i18n
-COPY --from=build --chown=nextjs:nodejs /app/messages ./messages
+COPY --from=build --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=build --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 USER nextjs
 EXPOSE 3000
 
-CMD ["npx", "next", "start", "--port", "3000", "--hostname", "0.0.0.0"]
+CMD ["node", "server.js"]

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -2,4 +2,6 @@ import createNextIntlPlugin from 'next-intl/plugin';
 
 const withNextIntl = createNextIntlPlugin('./i18n/request.ts');
 
-export default withNextIntl({});
+export default withNextIntl({
+  output: 'standalone',
+});


### PR DESCRIPTION
Switch runtime stage from copying full node_modules (~215 MB) to using Next.js standalone output (~50 MB). Also add docker image prune before pull in deploy workflow to prevent "no space left on device" errors.