### PR TITLE
fix(nginx): mount /var/www/certbot read-only into nginx container

### DIFF
--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -134,6 +134,12 @@ services:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/conf.d:/etc/nginx/conf.d:ro
       - /etc/letsencrypt:/etc/letsencrypt:ro
+      # Webroot for Let's Encrypt http-01 challenges. Certbot writes
+      # /.well-known/acme-challenge/<token> into this dir on the host;
+      # nginx's apex/app vhosts serve those files via the matching
+      # `location /.well-known/acme-challenge/` block. Required for
+      # `certbot --webroot` (used by cert-expand and auto-renew).
+      - /var/www/certbot:/var/www/certbot:ro
 
     depends_on:
       - api


### PR DESCRIPTION
Webroot-mode certbot (used by cert-expand.yml and the systemd renewal timer) writes challenge tokens to /var/www/certbot on the host and expects nginx to serve them at /.well-known/acme-challenge/<token>. Without a volume mount nginx returns 404, blocking new SAN expansion AND eventual auto-renewal of the existing cert.

The original cert was issued via certbot --standalone in bootstrap-vps.sh (before nginx came up), so this gap had not surfaced yet — the first renewal would have failed silently.