### PR TITLE
fix(website): bake app URL into prod build for Login link

### DIFF
--- a/.github/workflows/website-build-push.yml
+++ b/.github/workflows/website-build-push.yml
@@ -46,6 +46,8 @@ jobs:
           context: ./website
           file: ./website/Dockerfile.prod
           push: true
+          build-args: |
+            NEXT_PUBLIC_APP_URL=https://app.coach-os.be
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/website/Dockerfile.prod
+++ b/website/Dockerfile.prod
@@ -15,6 +15,11 @@ FROM node:22-alpine AS build
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+# NEXT_PUBLIC_* values are inlined into the client bundle at build time —
+# they MUST be set here, not as runtime env vars. Used by content/meta.ts
+# to point header/footer "Login" links at the actual app subdomain.
+ARG NEXT_PUBLIC_APP_URL=https://app.coach-os.be
+ENV NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL}
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN npm run build
 


### PR DESCRIPTION
NEXT_PUBLIC_APP_URL is read at build time by content/meta.ts to drive the Login button on the marketing site. The production build had no value for it, so the bundle inlined the localhost:5317 fallback and clicking "Login" on coach-os.be sent users to a dead address.

Pass it as a Docker build-arg with default https://app.coach-os.be in the website-build-push workflow and Dockerfile.prod (mirroring the existing frontend pattern for NEXT_PUBLIC_API_URL).