### PR TITLE
feat(org-settings): per-org settings entity with admins-act-as-trainers toggle

### DIFF
--- a/backend/CoachOS.API/Endpoints/OrganizationSettings/GetOrganizationSettingsEndpoint.cs
+++ b/backend/CoachOS.API/Endpoints/OrganizationSettings/GetOrganizationSettingsEndpoint.cs
@@ -14,7 +14,8 @@ public class GetOrganizationSettingsEndpoint : IEndpoint
             HttpContext ctx,
             CancellationToken ct) =>
         {
-            Result<OrganizationSettingsDto> result = await service.GetAsync(ctx.GetOrganizationId(), ct);
+            Result<OrganizationSettingsDto> result = await service.GetAsync(
+                ctx.GetOrganizationId(), ctx.GetUserId(), ct);
             return result.IsSuccess ? Results.Ok(result.Value) : result.ToErrorResult();
         })
         .RequireAuthorization(policy => policy.RequireRole("Admin"))

--- a/backend/CoachOS.API/Endpoints/OrganizationSettings/GetOrganizationSettingsEndpoint.cs
+++ b/backend/CoachOS.API/Endpoints/OrganizationSettings/GetOrganizationSettingsEndpoint.cs
@@ -1,0 +1,23 @@
+using CoachOS.API.Extensions;
+using CoachOS.Application.OrganizationSettings;
+using CoachOS.Application.OrganizationSettings.DTOs;
+using CoachOS.Domain.Models;
+
+namespace CoachOS.API.Endpoints.OrganizationSettings;
+
+public class GetOrganizationSettingsEndpoint : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/organization/settings", async (
+            IOrganizationSettingsService service,
+            HttpContext ctx,
+            CancellationToken ct) =>
+        {
+            Result<OrganizationSettingsDto> result = await service.GetAsync(ctx.GetOrganizationId(), ct);
+            return result.IsSuccess ? Results.Ok(result.Value) : result.ToErrorResult();
+        })
+        .RequireAuthorization(policy => policy.RequireRole("Admin"))
+        .WithTags("OrganizationSettings");
+    }
+}

--- a/backend/CoachOS.API/Endpoints/OrganizationSettings/UpdateOrganizationSettingsEndpoint.cs
+++ b/backend/CoachOS.API/Endpoints/OrganizationSettings/UpdateOrganizationSettingsEndpoint.cs
@@ -1,0 +1,27 @@
+using CoachOS.API.Extensions;
+using CoachOS.API.Filters;
+using CoachOS.Application.OrganizationSettings;
+using CoachOS.Application.OrganizationSettings.DTOs;
+using CoachOS.Domain.Models;
+
+namespace CoachOS.API.Endpoints.OrganizationSettings;
+
+public class UpdateOrganizationSettingsEndpoint : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPut("/organization/settings", async (
+            UpdateOrganizationSettingsRequest request,
+            IOrganizationSettingsService service,
+            HttpContext ctx,
+            CancellationToken ct) =>
+        {
+            Result<OrganizationSettingsDto> result = await service.UpdateAsync(
+                ctx.GetOrganizationId(), request, ct);
+            return result.IsSuccess ? Results.Ok(result.Value) : result.ToErrorResult();
+        })
+        .RequireAuthorization(policy => policy.RequireRole("Admin"))
+        .AddEndpointFilter<ValidationFilter<UpdateOrganizationSettingsRequest>>()
+        .WithTags("OrganizationSettings");
+    }
+}

--- a/backend/CoachOS.API/Endpoints/OrganizationSettings/UpdateOrganizationSettingsEndpoint.cs
+++ b/backend/CoachOS.API/Endpoints/OrganizationSettings/UpdateOrganizationSettingsEndpoint.cs
@@ -17,7 +17,7 @@ public class UpdateOrganizationSettingsEndpoint : IEndpoint
             CancellationToken ct) =>
         {
             Result<OrganizationSettingsDto> result = await service.UpdateAsync(
-                ctx.GetOrganizationId(), request, ct);
+                ctx.GetOrganizationId(), ctx.GetUserId(), request, ct);
             return result.IsSuccess ? Results.Ok(result.Value) : result.ToErrorResult();
         })
         .RequireAuthorization(policy => policy.RequireRole("Admin"))

--- a/backend/CoachOS.Application/DependencyInjection.cs
+++ b/backend/CoachOS.Application/DependencyInjection.cs
@@ -4,6 +4,7 @@ using CoachOS.Application.Enrollments;
 using CoachOS.Application.LessonReschedule;
 using CoachOS.Application.LessonSerie;
 using CoachOS.Application.Mappings;
+using CoachOS.Application.OrganizationSettings;
 using CoachOS.Application.Planning;
 using CoachOS.Application.Reschedule;
 using CoachOS.Application.StandaloneLessons;
@@ -35,6 +36,7 @@ public static class DependencyInjection
         services.AddScoped<ILessonRescheduleService, LessonRescheduleService>();
         services.AddScoped<IStandaloneLessonService, StandaloneLessonService>();
         services.AddScoped<IInvitationPublicService, InvitationPublicService>();
+        services.AddScoped<IOrganizationSettingsService, OrganizationSettingsService>();
 
         return services;
     }

--- a/backend/CoachOS.Application/Mappings/ApplicationMapper.cs
+++ b/backend/CoachOS.Application/Mappings/ApplicationMapper.cs
@@ -1,5 +1,6 @@
 using CoachOS.Application.Enrollments.DTOs;
 using CoachOS.Application.LessonSerie.DTOs;
+using CoachOS.Application.OrganizationSettings.DTOs;
 using CoachOS.Application.StandaloneLessons.DTOs;
 using CoachOS.Application.TennisClubs.DTOs;
 using CoachOS.Domain.Entities;
@@ -145,6 +146,11 @@ public partial class ApplicationMapper
             Name = club.Name,
             Address = club.Address,
         };
+    }
+
+    public OrganizationSettingsDto ToOrganizationSettingsDto(Domain.Entities.OrganizationSettings settings)
+    {
+        return new OrganizationSettingsDto(settings.AdminsActAsTrainers);
     }
 
     public InvitationDto ToInvitationDto(LessonInvitation invitation)

--- a/backend/CoachOS.Application/Mappings/ApplicationMapper.cs
+++ b/backend/CoachOS.Application/Mappings/ApplicationMapper.cs
@@ -148,9 +148,13 @@ public partial class ApplicationMapper
         };
     }
 
-    public OrganizationSettingsDto ToOrganizationSettingsDto(Domain.Entities.OrganizationSettings settings)
+    public OrganizationSettingsDto ToOrganizationSettingsDto(
+        Domain.Entities.OrganizationSettings settings,
+        int currentUserUpcomingLessonsAsTrainer)
     {
-        return new OrganizationSettingsDto(settings.AdminsActAsTrainers);
+        return new OrganizationSettingsDto(
+            settings.AdminsActAsTrainers,
+            currentUserUpcomingLessonsAsTrainer);
     }
 
     public InvitationDto ToInvitationDto(LessonInvitation invitation)

--- a/backend/CoachOS.Application/OrganizationSettings/DTOs/OrganizationSettingsDto.cs
+++ b/backend/CoachOS.Application/OrganizationSettings/DTOs/OrganizationSettingsDto.cs
@@ -1,0 +1,3 @@
+namespace CoachOS.Application.OrganizationSettings.DTOs;
+
+public record OrganizationSettingsDto(bool AdminsActAsTrainers);

--- a/backend/CoachOS.Application/OrganizationSettings/DTOs/OrganizationSettingsDto.cs
+++ b/backend/CoachOS.Application/OrganizationSettings/DTOs/OrganizationSettingsDto.cs
@@ -1,3 +1,10 @@
 namespace CoachOS.Application.OrganizationSettings.DTOs;
 
-public record OrganizationSettingsDto(bool AdminsActAsTrainers);
+/// <summary>
+/// Org-instellingen plus enkele context-velden over de huidige gebruiker zodat
+/// de FE waarschuwingen kan tonen bij het wijzigen (bv. nog openstaande lessen
+/// vóór toggle-off).
+/// </summary>
+public record OrganizationSettingsDto(
+    bool AdminsActAsTrainers,
+    int CurrentUserUpcomingLessonsAsTrainer);

--- a/backend/CoachOS.Application/OrganizationSettings/DTOs/UpdateOrganizationSettingsRequest.cs
+++ b/backend/CoachOS.Application/OrganizationSettings/DTOs/UpdateOrganizationSettingsRequest.cs
@@ -1,0 +1,3 @@
+namespace CoachOS.Application.OrganizationSettings.DTOs;
+
+public record UpdateOrganizationSettingsRequest(bool AdminsActAsTrainers);

--- a/backend/CoachOS.Application/OrganizationSettings/IOrganizationSettingsService.cs
+++ b/backend/CoachOS.Application/OrganizationSettings/IOrganizationSettingsService.cs
@@ -1,0 +1,18 @@
+using CoachOS.Application.OrganizationSettings.DTOs;
+using CoachOS.Domain.Models;
+
+namespace CoachOS.Application.OrganizationSettings;
+
+public interface IOrganizationSettingsService
+{
+    /// <summary>
+    /// Haalt de settings voor de gegeven org op. Maakt een rij aan met defaults
+    /// als die nog niet bestaat (lazy provisioning) zodat de FE altijd een payload terugkrijgt.
+    /// </summary>
+    Task<Result<OrganizationSettingsDto>> GetAsync(Guid organizationId, CancellationToken ct = default);
+
+    Task<Result<OrganizationSettingsDto>> UpdateAsync(
+        Guid organizationId,
+        UpdateOrganizationSettingsRequest request,
+        CancellationToken ct = default);
+}

--- a/backend/CoachOS.Application/OrganizationSettings/IOrganizationSettingsService.cs
+++ b/backend/CoachOS.Application/OrganizationSettings/IOrganizationSettingsService.cs
@@ -8,11 +8,17 @@ public interface IOrganizationSettingsService
     /// <summary>
     /// Haalt de settings voor de gegeven org op. Maakt een rij aan met defaults
     /// als die nog niet bestaat (lazy provisioning) zodat de FE altijd een payload terugkrijgt.
+    /// <paramref name="currentUserId"/> wordt gebruikt om context-velden te berekenen
+    /// (zoals openstaande lessen) voor waarschuwingen in de UI.
     /// </summary>
-    Task<Result<OrganizationSettingsDto>> GetAsync(Guid organizationId, CancellationToken ct = default);
+    Task<Result<OrganizationSettingsDto>> GetAsync(
+        Guid organizationId,
+        Guid currentUserId,
+        CancellationToken ct = default);
 
     Task<Result<OrganizationSettingsDto>> UpdateAsync(
         Guid organizationId,
+        Guid currentUserId,
         UpdateOrganizationSettingsRequest request,
         CancellationToken ct = default);
 }

--- a/backend/CoachOS.Application/OrganizationSettings/OrganizationSettingsService.cs
+++ b/backend/CoachOS.Application/OrganizationSettings/OrganizationSettingsService.cs
@@ -7,23 +7,31 @@ namespace CoachOS.Application.OrganizationSettings;
 
 public class OrganizationSettingsService(
     IOrganizationSettingsRepository repo,
+    ILessonRepository lessonRepo,
     ApplicationMapper mapper) : IOrganizationSettingsService
 {
-    public async Task<Result<OrganizationSettingsDto>> GetAsync(Guid organizationId, CancellationToken ct = default)
+    public async Task<Result<OrganizationSettingsDto>> GetAsync(
+        Guid organizationId,
+        Guid currentUserId,
+        CancellationToken ct = default)
     {
         Domain.Entities.OrganizationSettings settings = await GetOrCreateAsync(organizationId, ct);
-        return Result<OrganizationSettingsDto>.Ok(mapper.ToOrganizationSettingsDto(settings));
+        int upcoming = await CountUpcomingForCurrentUserAsync(currentUserId, organizationId, ct);
+        return Result<OrganizationSettingsDto>.Ok(mapper.ToOrganizationSettingsDto(settings, upcoming));
     }
 
     public async Task<Result<OrganizationSettingsDto>> UpdateAsync(
         Guid organizationId,
+        Guid currentUserId,
         UpdateOrganizationSettingsRequest request,
         CancellationToken ct = default)
     {
         Domain.Entities.OrganizationSettings settings = await GetOrCreateAsync(organizationId, ct);
         settings.AdminsActAsTrainers = request.AdminsActAsTrainers;
         await repo.SaveChangesAsync(ct);
-        return Result<OrganizationSettingsDto>.Ok(mapper.ToOrganizationSettingsDto(settings));
+
+        int upcoming = await CountUpcomingForCurrentUserAsync(currentUserId, organizationId, ct);
+        return Result<OrganizationSettingsDto>.Ok(mapper.ToOrganizationSettingsDto(settings, upcoming));
     }
 
     private async Task<Domain.Entities.OrganizationSettings> GetOrCreateAsync(Guid organizationId, CancellationToken ct)
@@ -39,5 +47,11 @@ public class OrganizationSettingsService(
         await repo.AddAsync(created, ct);
         await repo.SaveChangesAsync(ct);
         return created;
+    }
+
+    private Task<int> CountUpcomingForCurrentUserAsync(Guid userId, Guid organizationId, CancellationToken ct)
+    {
+        DateOnly today = DateOnly.FromDateTime(DateTime.UtcNow);
+        return lessonRepo.CountUpcomingForTrainerAsync(userId, organizationId, today, ct);
     }
 }

--- a/backend/CoachOS.Application/OrganizationSettings/OrganizationSettingsService.cs
+++ b/backend/CoachOS.Application/OrganizationSettings/OrganizationSettingsService.cs
@@ -1,0 +1,43 @@
+using CoachOS.Application.Mappings;
+using CoachOS.Application.OrganizationSettings.DTOs;
+using CoachOS.Domain.Interfaces;
+using CoachOS.Domain.Models;
+
+namespace CoachOS.Application.OrganizationSettings;
+
+public class OrganizationSettingsService(
+    IOrganizationSettingsRepository repo,
+    ApplicationMapper mapper) : IOrganizationSettingsService
+{
+    public async Task<Result<OrganizationSettingsDto>> GetAsync(Guid organizationId, CancellationToken ct = default)
+    {
+        Domain.Entities.OrganizationSettings settings = await GetOrCreateAsync(organizationId, ct);
+        return Result<OrganizationSettingsDto>.Ok(mapper.ToOrganizationSettingsDto(settings));
+    }
+
+    public async Task<Result<OrganizationSettingsDto>> UpdateAsync(
+        Guid organizationId,
+        UpdateOrganizationSettingsRequest request,
+        CancellationToken ct = default)
+    {
+        Domain.Entities.OrganizationSettings settings = await GetOrCreateAsync(organizationId, ct);
+        settings.AdminsActAsTrainers = request.AdminsActAsTrainers;
+        await repo.SaveChangesAsync(ct);
+        return Result<OrganizationSettingsDto>.Ok(mapper.ToOrganizationSettingsDto(settings));
+    }
+
+    private async Task<Domain.Entities.OrganizationSettings> GetOrCreateAsync(Guid organizationId, CancellationToken ct)
+    {
+        Domain.Entities.OrganizationSettings? existing = await repo.GetByOrganizationAsync(organizationId, ct);
+        if (existing is not null) return existing;
+
+        Domain.Entities.OrganizationSettings created = new()
+        {
+            OrganizationId = organizationId,
+            AdminsActAsTrainers = true,
+        };
+        await repo.AddAsync(created, ct);
+        await repo.SaveChangesAsync(ct);
+        return created;
+    }
+}

--- a/backend/CoachOS.Application/OrganizationSettings/Validators/UpdateOrganizationSettingsRequestValidator.cs
+++ b/backend/CoachOS.Application/OrganizationSettings/Validators/UpdateOrganizationSettingsRequestValidator.cs
@@ -1,0 +1,14 @@
+using CoachOS.Application.OrganizationSettings.DTOs;
+using FluentValidation;
+
+namespace CoachOS.Application.OrganizationSettings.Validators;
+
+public class UpdateOrganizationSettingsRequestValidator : AbstractValidator<UpdateOrganizationSettingsRequest>
+{
+    public UpdateOrganizationSettingsRequestValidator()
+    {
+        // Geen veld-niveau regels: AdminsActAsTrainers is een verplichte bool en kan
+        // beide waarden aannemen. Dit class staat klaar voor toekomstige settings die wél
+        // validatie nodig hebben (bv. enum-velden, ranges, regex).
+    }
+}

--- a/backend/CoachOS.Domain/Entities/Organization.cs
+++ b/backend/CoachOS.Domain/Entities/Organization.cs
@@ -20,4 +20,5 @@ public class Organization : BaseEntity
     // Navigation properties
     public ICollection<LessonSerie> LessonSeries { get; set; } = new List<LessonSerie>();
     public Subscription? Subscription { get; set; }
+    public OrganizationSettings? Settings { get; set; }
 }

--- a/backend/CoachOS.Domain/Entities/OrganizationSettings.cs
+++ b/backend/CoachOS.Domain/Entities/OrganizationSettings.cs
@@ -1,0 +1,21 @@
+using CoachOS.Domain.Common;
+
+namespace CoachOS.Domain.Entities;
+
+/// <summary>
+/// Per-organisatie instellingen. 1-1 relatie met <see cref="Organization"/>.
+/// Nieuwe org-brede toggles worden hier toegevoegd zodat <see cref="Organization"/> beperkt blijft tot identiteit.
+/// </summary>
+public class OrganizationSettings : BaseEntity
+{
+    public Guid OrganizationId { get; set; }
+
+    /// <summary>
+    /// True wanneer de admin van deze organisatie automatisch in de trainerlijst verschijnt
+    /// en lessen toegewezen kan krijgen. Default true: een tennisschool runt typisch op één
+    /// admin-coach combinatie. Zet op false wanneer de admin puur administratief is.
+    /// </summary>
+    public bool AdminsActAsTrainers { get; set; } = true;
+
+    public Organization Organization { get; set; } = null!;
+}

--- a/backend/CoachOS.Domain/Interfaces/ILessonRepository.cs
+++ b/backend/CoachOS.Domain/Interfaces/ILessonRepository.cs
@@ -7,6 +7,14 @@ public interface ILessonRepository
     Task<Lesson?> GetByIdAsync(Guid lessonId, Guid seriesId, Guid organizationId, CancellationToken ct = default);
     Task<Lesson?> GetByIdWithEnrollmentsAsync(Guid lessonId, Guid seriesId, Guid organizationId, CancellationToken ct = default);
     Task<int> CountBySeriesIdAsync(Guid seriesId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Telt actieve (niet-gecancelde) lessen vanaf <paramref name="fromDate"/>
+    /// waarvan de trainer de gegeven user is, binnen de organisatie.
+    /// Gebruikt om de admin te waarschuwen vóór toggle-off van AdminsActAsTrainers.
+    /// </summary>
+    Task<int> CountUpcomingForTrainerAsync(
+        Guid trainerId, Guid organizationId, DateOnly fromDate, CancellationToken ct = default);
     Task<Dictionary<Guid, int>> GetLessonCountsBySeriesIdsAsync(IEnumerable<Guid> seriesIds, CancellationToken ct = default);
     Task<List<Lesson>> GetUpcomingByOrganizationAsync(Guid organizationId, DateOnly fromDate, int limit, CancellationToken ct = default);
     Task<int> CountByOrganizationAndDateRangeAsync(Guid organizationId, DateOnly from, DateOnly to, CancellationToken ct = default);

--- a/backend/CoachOS.Domain/Interfaces/IOrganizationSettingsRepository.cs
+++ b/backend/CoachOS.Domain/Interfaces/IOrganizationSettingsRepository.cs
@@ -1,0 +1,15 @@
+using CoachOS.Domain.Entities;
+
+namespace CoachOS.Domain.Interfaces;
+
+public interface IOrganizationSettingsRepository
+{
+    /// <summary>Tracked read; gebruik voor mutaties.</summary>
+    Task<OrganizationSettings?> GetByOrganizationAsync(Guid organizationId, CancellationToken ct = default);
+
+    /// <summary>AsNoTracking read; gebruik voor query-paden zoals trainerlijst-filtering.</summary>
+    Task<OrganizationSettings?> GetByOrganizationReadOnlyAsync(Guid organizationId, CancellationToken ct = default);
+
+    Task AddAsync(OrganizationSettings settings, CancellationToken ct = default);
+    Task SaveChangesAsync(CancellationToken ct = default);
+}

--- a/backend/CoachOS.Infrastructure/DependencyInjection.cs
+++ b/backend/CoachOS.Infrastructure/DependencyInjection.cs
@@ -75,6 +75,7 @@ public static class DependencyInjection
         services.AddScoped<IStudentMagicLinkService, StudentMagicLinkService>();
         services.AddScoped<IRescheduleRequestRepository, RescheduleRequestRepository>();
         services.AddScoped<ILessonInvitationRepository, LessonInvitationRepository>();
+        services.AddScoped<IOrganizationSettingsRepository, OrganizationSettingsRepository>();
 
         return services;
     }

--- a/backend/CoachOS.Infrastructure/Identity/AuthService.cs
+++ b/backend/CoachOS.Infrastructure/Identity/AuthService.cs
@@ -53,6 +53,17 @@ public class AuthService(
             };
 
             context.Organizations.Add(organization);
+
+            // Initialiseer org-settings met defaults zodat de FE bij eerste GET geen lazy
+            // provisioning hoeft te triggeren. AdminsActAsTrainers default true: een
+            // tennisschool draait typisch op de admin-coach combinatie.
+            context.OrganizationSettings.Add(new Domain.Entities.OrganizationSettings
+            {
+                Id = Guid.NewGuid(),
+                OrganizationId = organization.Id,
+                AdminsActAsTrainers = true,
+            });
+
             await context.SaveChangesAsync(cancellationToken);
 
             ApplicationUser user = new()

--- a/backend/CoachOS.Infrastructure/Identity/TrainerService.cs
+++ b/backend/CoachOS.Infrastructure/Identity/TrainerService.cs
@@ -16,7 +16,8 @@ public class TrainerService(
     UserManager<ApplicationUser> userManager,
     TokenService tokenService,
     IEmailService emailService,
-    ApplicationDbContext context)
+    ApplicationDbContext context,
+    IOrganizationSettingsRepository settingsRepo)
     : ITrainerService
 {
     public async Task<Result<Guid>> InviteAsync(
@@ -210,11 +211,17 @@ public class TrainerService(
         // Trainers zijn alle memberships (Trainer-rol) in deze org, via join met users.
         // Pending invites (m.IsActive == false, u.InviteToken != null) blijven meekomen
         // zodat de admin uitstaande uitnodigingen ziet en kan opnieuw versturen.
+        // Admin verschijnt mee in de lijst wanneer de org-setting AdminsActAsTrainers
+        // aanstaat (default true; zet uit op /dashboard/settings voor zuiver-administratieve admins).
+        Domain.Entities.OrganizationSettings? settings =
+            await settingsRepo.GetByOrganizationReadOnlyAsync(organizationId, ct);
+        bool includeAdmins = settings?.AdminsActAsTrainers ?? true;
+
         var query =
             from m in context.OrganizationMemberships.AsNoTracking()
             join u in context.Users.AsNoTracking() on m.UserId equals u.Id
             where m.OrganizationId == organizationId
-                  && m.Role == UserRole.Trainer
+                  && (m.Role == UserRole.Trainer || (includeAdmins && m.Role == UserRole.Admin))
             orderby u.FirstName, u.LastName
             select new TrainerDto
             {

--- a/backend/CoachOS.Infrastructure/Identity/UserLookupService.cs
+++ b/backend/CoachOS.Infrastructure/Identity/UserLookupService.cs
@@ -33,7 +33,7 @@ public class UserLookupService(
     {
         // Tenant-scoped via OrganizationMembership ipv de legacy user.OrganizationId.
         // Admin telt alleen mee als trainer wanneer de org-setting AdminsActAsTrainers aanstaat.
-        bool adminsCount = await AdminsActAsTrainersAsync(organizationId, ct);
+        bool includeAdmins = await AdminsActAsTrainersAsync(organizationId, ct);
 
         var query =
             from m in context.OrganizationMemberships.AsNoTracking()
@@ -41,7 +41,7 @@ public class UserLookupService(
             where m.OrganizationId == organizationId
                   && m.IsActive
                   && u.IsActive
-                  && (m.Role == UserRole.Trainer || (adminsCount && m.Role == UserRole.Admin))
+                  && (m.Role == UserRole.Trainer || (includeAdmins && m.Role == UserRole.Admin))
             orderby u.FirstName, u.LastName
             select new { u.Id, u.FirstName, u.LastName };
 
@@ -53,13 +53,13 @@ public class UserLookupService(
     {
         // Tenant-scoped membership check. Admin telt alleen mee als trainer wanneer de
         // org-setting AdminsActAsTrainers aanstaat.
-        bool adminsCount = await AdminsActAsTrainersAsync(organizationId, ct);
+        bool includeAdmins = await AdminsActAsTrainersAsync(organizationId, ct);
 
         return await context.OrganizationMemberships
             .AsNoTracking()
             .AnyAsync(m => m.UserId == trainerId
                 && m.OrganizationId == organizationId
-                && (m.Role == UserRole.Trainer || (adminsCount && m.Role == UserRole.Admin))
+                && (m.Role == UserRole.Trainer || (includeAdmins && m.Role == UserRole.Admin))
                 && m.IsActive, ct);
     }
 

--- a/backend/CoachOS.Infrastructure/Identity/UserLookupService.cs
+++ b/backend/CoachOS.Infrastructure/Identity/UserLookupService.cs
@@ -5,7 +5,9 @@ using Microsoft.EntityFrameworkCore;
 
 namespace CoachOS.Infrastructure.Identity;
 
-public class UserLookupService(ApplicationDbContext context) : IUserLookupService
+public class UserLookupService(
+    ApplicationDbContext context,
+    IOrganizationSettingsRepository settingsRepo) : IUserLookupService
 {
     public async Task<Dictionary<Guid, string>> GetUserNamesByIdsAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
     {
@@ -30,13 +32,16 @@ public class UserLookupService(ApplicationDbContext context) : IUserLookupServic
     public async Task<List<(Guid Id, string FullName)>> GetOrganizationMembersAsync(Guid organizationId, CancellationToken ct = default)
     {
         // Tenant-scoped via OrganizationMembership ipv de legacy user.OrganizationId.
+        // Admin telt alleen mee als trainer wanneer de org-setting AdminsActAsTrainers aanstaat.
+        bool adminsCount = await AdminsActAsTrainersAsync(organizationId, ct);
+
         var query =
             from m in context.OrganizationMemberships.AsNoTracking()
             join u in context.Users.AsNoTracking() on m.UserId equals u.Id
             where m.OrganizationId == organizationId
                   && m.IsActive
                   && u.IsActive
-                  && (m.Role == UserRole.Trainer || m.Role == UserRole.Admin)
+                  && (m.Role == UserRole.Trainer || (adminsCount && m.Role == UserRole.Admin))
             orderby u.FirstName, u.LastName
             select new { u.Id, u.FirstName, u.LastName };
 
@@ -46,13 +51,27 @@ public class UserLookupService(ApplicationDbContext context) : IUserLookupServic
 
     public async Task<bool> IsActiveTrainerAsync(Guid trainerId, Guid organizationId, CancellationToken ct = default)
     {
-        // Tenant-scoped membership check.
+        // Tenant-scoped membership check. Admin telt alleen mee als trainer wanneer de
+        // org-setting AdminsActAsTrainers aanstaat.
+        bool adminsCount = await AdminsActAsTrainersAsync(organizationId, ct);
+
         return await context.OrganizationMemberships
             .AsNoTracking()
             .AnyAsync(m => m.UserId == trainerId
                 && m.OrganizationId == organizationId
-                && (m.Role == UserRole.Trainer || m.Role == UserRole.Admin)
+                && (m.Role == UserRole.Trainer || (adminsCount && m.Role == UserRole.Admin))
                 && m.IsActive, ct);
+    }
+
+    /// <summary>
+    /// Leest de AdminsActAsTrainers vlag. Bij ontbrekende settings-rij default true,
+    /// zo blijft historisch gedrag bewaard tot de migratie de backfill heeft gedaan.
+    /// </summary>
+    private async Task<bool> AdminsActAsTrainersAsync(Guid organizationId, CancellationToken ct)
+    {
+        Domain.Entities.OrganizationSettings? settings =
+            await settingsRepo.GetByOrganizationReadOnlyAsync(organizationId, ct);
+        return settings?.AdminsActAsTrainers ?? true;
     }
 
     public async Task<int> CountActiveTrainersAsync(Guid organizationId, CancellationToken ct = default)

--- a/backend/CoachOS.Infrastructure/Migrations/20260515121819_AddOrganizationSettings.Designer.cs
+++ b/backend/CoachOS.Infrastructure/Migrations/20260515121819_AddOrganizationSettings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CoachOS.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CoachOS.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260515121819_AddOrganizationSettings")]
+    partial class AddOrganizationSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/CoachOS.Infrastructure/Migrations/20260515121819_AddOrganizationSettings.cs
+++ b/backend/CoachOS.Infrastructure/Migrations/20260515121819_AddOrganizationSettings.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CoachOS.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOrganizationSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "OrganizationSettings",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    OrganizationId = table.Column<Guid>(type: "uuid", nullable: false),
+                    AdminsActAsTrainers = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OrganizationSettings", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_OrganizationSettings_Organizations_OrganizationId",
+                        column: x => x.OrganizationId,
+                        principalTable: "Organizations",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrganizationSettings_OrganizationId",
+                table: "OrganizationSettings",
+                column: "OrganizationId",
+                unique: true);
+
+            // Backfill: bestaande organisaties krijgen een settings-rij met defaults
+            // (AdminsActAsTrainers = true). Dit bewaart het historische gedrag waarbij
+            // admins automatisch als trainer fungeerden (UserLookupService.IsActiveTrainerAsync
+            // accepteerde Admin || Trainer).
+            migrationBuilder.Sql(@"
+                INSERT INTO ""OrganizationSettings"" (""Id"", ""OrganizationId"", ""AdminsActAsTrainers"", ""CreatedAt"", ""UpdatedAt"")
+                SELECT gen_random_uuid(), o.""Id"", true, NOW() AT TIME ZONE 'UTC', NOW() AT TIME ZONE 'UTC'
+                FROM ""Organizations"" o
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM ""OrganizationSettings"" s WHERE s.""OrganizationId"" = o.""Id""
+                );
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OrganizationSettings");
+        }
+    }
+}

--- a/backend/CoachOS.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/backend/CoachOS.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -43,6 +43,7 @@ public class ApplicationDbContext(
     public DbSet<OrganizationMembership> OrganizationMemberships { get; set; } = null!;
     public DbSet<RescheduleRequest> RescheduleRequests { get; set; } = null!;
     public DbSet<LessonInvitation> LessonInvitations { get; set; } = null!;
+    public DbSet<OrganizationSettings> OrganizationSettings { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
@@ -67,6 +68,7 @@ public class ApplicationDbContext(
         builder.ApplyConfiguration(new OrganizationMembershipConfiguration());
         builder.ApplyConfiguration(new RescheduleRequestConfiguration());
         builder.ApplyConfiguration(new LessonInvitationConfiguration());
+        builder.ApplyConfiguration(new OrganizationSettingsConfiguration());
 
         ApplyTenantFilters(builder);
     }
@@ -104,6 +106,8 @@ public class ApplicationDbContext(
         builder.Entity<RescheduleRequest>().HasQueryFilter(e =>
             _tenant.OrganizationId == Guid.Empty || e.OrganizationId == _tenant.OrganizationId);
         builder.Entity<LessonInvitation>().HasQueryFilter(e =>
+            _tenant.OrganizationId == Guid.Empty || e.OrganizationId == _tenant.OrganizationId);
+        builder.Entity<OrganizationSettings>().HasQueryFilter(e =>
             _tenant.OrganizationId == Guid.Empty || e.OrganizationId == _tenant.OrganizationId);
     }
 

--- a/backend/CoachOS.Infrastructure/Persistence/Configurations/OrganizationSettingsConfiguration.cs
+++ b/backend/CoachOS.Infrastructure/Persistence/Configurations/OrganizationSettingsConfiguration.cs
@@ -1,0 +1,24 @@
+using CoachOS.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace CoachOS.Infrastructure.Persistence.Configurations;
+
+public class OrganizationSettingsConfiguration : IEntityTypeConfiguration<OrganizationSettings>
+{
+    public void Configure(EntityTypeBuilder<OrganizationSettings> builder)
+    {
+        builder.HasKey(s => s.Id);
+
+        builder.Property(s => s.AdminsActAsTrainers)
+            .IsRequired()
+            .HasDefaultValue(true);
+
+        builder.HasOne(s => s.Organization)
+            .WithOne(o => o.Settings)
+            .HasForeignKey<OrganizationSettings>(s => s.OrganizationId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasIndex(s => s.OrganizationId).IsUnique();
+    }
+}

--- a/backend/CoachOS.Infrastructure/Repositories/LessonRepository.cs
+++ b/backend/CoachOS.Infrastructure/Repositories/LessonRepository.cs
@@ -35,6 +35,17 @@ public class LessonRepository(ApplicationDbContext context) : ILessonRepository
             .CountAsync(l => l.LessonSerieId == seriesId, ct);
     }
 
+    public async Task<int> CountUpcomingForTrainerAsync(
+        Guid trainerId, Guid organizationId, DateOnly fromDate, CancellationToken ct = default)
+    {
+        return await context.Lessons
+            .AsNoTracking()
+            .CountAsync(l => l.TrainerId == trainerId
+                && l.OrganizationId == organizationId
+                && l.Date >= fromDate
+                && !l.IsCancelled, ct);
+    }
+
     public async Task<Dictionary<Guid, int>> GetLessonCountsBySeriesIdsAsync(
         IEnumerable<Guid> seriesIds, CancellationToken ct = default)
     {

--- a/backend/CoachOS.Infrastructure/Repositories/OrganizationSettingsRepository.cs
+++ b/backend/CoachOS.Infrastructure/Repositories/OrganizationSettingsRepository.cs
@@ -1,0 +1,32 @@
+using CoachOS.Domain.Entities;
+using CoachOS.Domain.Interfaces;
+using CoachOS.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace CoachOS.Infrastructure.Repositories;
+
+public class OrganizationSettingsRepository(ApplicationDbContext context) : IOrganizationSettingsRepository
+{
+    public async Task<OrganizationSettings?> GetByOrganizationAsync(Guid organizationId, CancellationToken ct = default)
+    {
+        return await context.OrganizationSettings
+            .FirstOrDefaultAsync(s => s.OrganizationId == organizationId, ct);
+    }
+
+    public async Task<OrganizationSettings?> GetByOrganizationReadOnlyAsync(Guid organizationId, CancellationToken ct = default)
+    {
+        return await context.OrganizationSettings
+            .AsNoTracking()
+            .FirstOrDefaultAsync(s => s.OrganizationId == organizationId, ct);
+    }
+
+    public async Task AddAsync(OrganizationSettings settings, CancellationToken ct = default)
+    {
+        await context.OrganizationSettings.AddAsync(settings, ct);
+    }
+
+    public async Task SaveChangesAsync(CancellationToken ct = default)
+    {
+        await context.SaveChangesAsync(ct);
+    }
+}

--- a/backend/CoachOS.Tests/Services/OrganizationSettingsServiceTests.cs
+++ b/backend/CoachOS.Tests/Services/OrganizationSettingsServiceTests.cs
@@ -13,17 +13,24 @@ namespace CoachOS.Tests.Services;
 public class OrganizationSettingsServiceTests
 {
     private Mock<IOrganizationSettingsRepository> _repo = null!;
+    private Mock<ILessonRepository> _lessonRepo = null!;
     private ApplicationMapper _mapper = null!;
     private OrganizationSettingsService _sut = null!;
 
     private static readonly Guid OrgId = Guid.NewGuid();
+    private static readonly Guid UserId = Guid.NewGuid();
 
     [SetUp]
     public void SetUp()
     {
         _repo = new Mock<IOrganizationSettingsRepository>();
+        _lessonRepo = new Mock<ILessonRepository>();
+        _lessonRepo
+            .Setup(r => r.CountUpcomingForTrainerAsync(
+                It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
         _mapper = new ApplicationMapper();
-        _sut = new OrganizationSettingsService(_repo.Object, _mapper);
+        _sut = new OrganizationSettingsService(_repo.Object, _lessonRepo.Object, _mapper);
     }
 
     [Test]
@@ -38,7 +45,7 @@ public class OrganizationSettingsServiceTests
         _repo.Setup(r => r.GetByOrganizationAsync(OrgId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(existing);
 
-        var result = await _sut.GetAsync(OrgId);
+        var result = await _sut.GetAsync(OrgId, UserId);
 
         result.IsSuccess.Should().BeTrue();
         result.Value!.AdminsActAsTrainers.Should().BeFalse();
@@ -51,7 +58,7 @@ public class OrganizationSettingsServiceTests
         _repo.Setup(r => r.GetByOrganizationAsync(OrgId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((OrganizationSettings?)null);
 
-        var result = await _sut.GetAsync(OrgId);
+        var result = await _sut.GetAsync(OrgId, UserId);
 
         result.IsSuccess.Should().BeTrue();
         result.Value!.AdminsActAsTrainers.Should().BeTrue();
@@ -75,12 +82,34 @@ public class OrganizationSettingsServiceTests
 
         UpdateOrganizationSettingsRequest request = new(AdminsActAsTrainers: false);
 
-        var result = await _sut.UpdateAsync(OrgId, request);
+        var result = await _sut.UpdateAsync(OrgId, UserId, request);
 
         result.IsSuccess.Should().BeTrue();
         result.Value!.AdminsActAsTrainers.Should().BeFalse();
         existing.AdminsActAsTrainers.Should().BeFalse();
         _repo.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task GetAsync_IncludesUpcomingLessonCountForCurrentUser()
+    {
+        OrganizationSettings existing = new()
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = OrgId,
+            AdminsActAsTrainers = true,
+        };
+        _repo.Setup(r => r.GetByOrganizationAsync(OrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        _lessonRepo
+            .Setup(r => r.CountUpcomingForTrainerAsync(
+                UserId, OrgId, It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(7);
+
+        var result = await _sut.GetAsync(OrgId, UserId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.CurrentUserUpcomingLessonsAsTrainer.Should().Be(7);
     }
 
     [Test]
@@ -91,7 +120,7 @@ public class OrganizationSettingsServiceTests
 
         UpdateOrganizationSettingsRequest request = new(AdminsActAsTrainers: false);
 
-        var result = await _sut.UpdateAsync(OrgId, request);
+        var result = await _sut.UpdateAsync(OrgId, UserId, request);
 
         result.IsSuccess.Should().BeTrue();
         result.Value!.AdminsActAsTrainers.Should().BeFalse();

--- a/backend/CoachOS.Tests/Services/OrganizationSettingsServiceTests.cs
+++ b/backend/CoachOS.Tests/Services/OrganizationSettingsServiceTests.cs
@@ -1,0 +1,102 @@
+using CoachOS.Application.Mappings;
+using CoachOS.Application.OrganizationSettings;
+using CoachOS.Application.OrganizationSettings.DTOs;
+using CoachOS.Domain.Entities;
+using CoachOS.Domain.Interfaces;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+
+namespace CoachOS.Tests.Services;
+
+[TestFixture]
+public class OrganizationSettingsServiceTests
+{
+    private Mock<IOrganizationSettingsRepository> _repo = null!;
+    private ApplicationMapper _mapper = null!;
+    private OrganizationSettingsService _sut = null!;
+
+    private static readonly Guid OrgId = Guid.NewGuid();
+
+    [SetUp]
+    public void SetUp()
+    {
+        _repo = new Mock<IOrganizationSettingsRepository>();
+        _mapper = new ApplicationMapper();
+        _sut = new OrganizationSettingsService(_repo.Object, _mapper);
+    }
+
+    [Test]
+    public async Task GetAsync_ExistingSettings_ReturnsDto()
+    {
+        OrganizationSettings existing = new()
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = OrgId,
+            AdminsActAsTrainers = false,
+        };
+        _repo.Setup(r => r.GetByOrganizationAsync(OrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+
+        var result = await _sut.GetAsync(OrgId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.AdminsActAsTrainers.Should().BeFalse();
+        _repo.Verify(r => r.AddAsync(It.IsAny<OrganizationSettings>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task GetAsync_MissingSettings_LazyCreatesWithDefaultTrue()
+    {
+        _repo.Setup(r => r.GetByOrganizationAsync(OrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((OrganizationSettings?)null);
+
+        var result = await _sut.GetAsync(OrgId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.AdminsActAsTrainers.Should().BeTrue();
+        _repo.Verify(r => r.AddAsync(
+            It.Is<OrganizationSettings>(s => s.OrganizationId == OrgId && s.AdminsActAsTrainers),
+            It.IsAny<CancellationToken>()), Times.Once);
+        _repo.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task UpdateAsync_PersistsNewValueAndReturnsDto()
+    {
+        OrganizationSettings existing = new()
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = OrgId,
+            AdminsActAsTrainers = true,
+        };
+        _repo.Setup(r => r.GetByOrganizationAsync(OrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+
+        UpdateOrganizationSettingsRequest request = new(AdminsActAsTrainers: false);
+
+        var result = await _sut.UpdateAsync(OrgId, request);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.AdminsActAsTrainers.Should().BeFalse();
+        existing.AdminsActAsTrainers.Should().BeFalse();
+        _repo.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task UpdateAsync_MissingSettings_CreatesAndApplies()
+    {
+        _repo.Setup(r => r.GetByOrganizationAsync(OrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((OrganizationSettings?)null);
+
+        UpdateOrganizationSettingsRequest request = new(AdminsActAsTrainers: false);
+
+        var result = await _sut.UpdateAsync(OrgId, request);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.AdminsActAsTrainers.Should().BeFalse();
+        _repo.Verify(r => r.AddAsync(It.IsAny<OrganizationSettings>(), It.IsAny<CancellationToken>()), Times.Once);
+        // Eén SaveChanges voor de create, één voor de update.
+        _repo.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+}

--- a/frontend/app/(dashboard)/dashboard/settings/organization-section.tsx
+++ b/frontend/app/(dashboard)/dashboard/settings/organization-section.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useTranslations } from "next-intl";
+import { Settings as SettingsIcon } from "lucide-react";
+import {
+  getOrganizationSettings,
+  updateOrganizationSettings,
+} from "@/lib/api/organizationSettings";
+
+export function OrganizationSection() {
+  const t = useTranslations("organizationSettings");
+  const queryClient = useQueryClient();
+
+  const { data: settings, isLoading } = useQuery({
+    queryKey: ["organizationSettings"],
+    queryFn: getOrganizationSettings,
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: updateOrganizationSettings,
+    onSuccess: (data) => {
+      queryClient.setQueryData(["organizationSettings"], data);
+      // Trainerlijst hangt af van deze setting — verver hem.
+      queryClient.invalidateQueries({ queryKey: ["trainers"] });
+    },
+  });
+
+  function handleToggleAdminsActAsTrainers(next: boolean) {
+    updateMutation.mutate({ adminsActAsTrainers: next });
+  }
+
+  const isOn = settings?.adminsActAsTrainers ?? false;
+  const disabled = isLoading || updateMutation.isPending;
+
+  return (
+    <div className="bg-white rounded-xl shadow-sm shadow-gray-100 overflow-hidden mb-6">
+      {/* Section header */}
+      <div className="px-6 py-4 border-b border-gray-100 flex items-center gap-2.5">
+        <div className="w-7 h-7 rounded-lg bg-tennis-green/10 flex items-center justify-center">
+          <SettingsIcon size={14} className="text-tennis-green" />
+        </div>
+        <div>
+          <h2 className="text-sm font-semibold text-gray-800">
+            {t("sectionTitle")}
+          </h2>
+          <p className="text-xs text-gray-400">{t("sectionSubtitle")}</p>
+        </div>
+      </div>
+
+      {/* Toggle row */}
+      <div className="p-5">
+        <label className="flex items-start justify-between gap-4 cursor-pointer">
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-semibold text-gray-800">
+              {t("adminsActAsTrainersLabel")}
+            </p>
+            <p className="text-xs text-gray-500 mt-1 leading-relaxed">
+              {t("adminsActAsTrainersHelp")}
+            </p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={isOn}
+            disabled={disabled}
+            onClick={() => handleToggleAdminsActAsTrainers(!isOn)}
+            className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors mt-0.5 disabled:opacity-50 disabled:cursor-not-allowed ${
+              isOn ? "bg-tennis-green" : "bg-gray-200"
+            }`}
+          >
+            <span
+              className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                isOn ? "translate-x-6" : "translate-x-1"
+              }`}
+            />
+          </button>
+        </label>
+
+        {updateMutation.isError && (
+          <p className="text-xs text-red-500 mt-3">{t("saveError")}</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/(dashboard)/dashboard/settings/organization-section.tsx
+++ b/frontend/app/(dashboard)/dashboard/settings/organization-section.tsx
@@ -1,16 +1,31 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
-import { Settings as SettingsIcon } from "lucide-react";
+import { Check, Settings as SettingsIcon } from "lucide-react";
 import {
   getOrganizationSettings,
   updateOrganizationSettings,
 } from "@/lib/api/organizationSettings";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+const SAVED_HINT_MS = 1800;
 
 export function OrganizationSection() {
   const t = useTranslations("organizationSettings");
   const queryClient = useQueryClient();
+  const [showOffConfirm, setShowOffConfirm] = useState(false);
+  const [savedAt, setSavedAt] = useState<number | null>(null);
 
   const { data: settings, isLoading } = useQuery({
     queryKey: ["organizationSettings"],
@@ -23,64 +38,118 @@ export function OrganizationSection() {
       queryClient.setQueryData(["organizationSettings"], data);
       // Trainerlijst hangt af van deze setting — verver hem.
       queryClient.invalidateQueries({ queryKey: ["trainers"] });
+      setSavedAt(Date.now());
     },
   });
 
-  function handleToggleAdminsActAsTrainers(next: boolean) {
+  // Verstop de "opgeslagen"-hint automatisch na SAVED_HINT_MS.
+  useEffect(() => {
+    if (savedAt === null) return;
+    const id = setTimeout(() => setSavedAt(null), SAVED_HINT_MS);
+    return () => clearTimeout(id);
+  }, [savedAt]);
+
+  function commit(next: boolean) {
     updateMutation.mutate({ adminsActAsTrainers: next });
+  }
+
+  function handleClick() {
+    if (!settings) return;
+    const next = !settings.adminsActAsTrainers;
+    // Toggle-off met openstaande lessen → eerst bevestigen.
+    if (!next && settings.currentUserUpcomingLessonsAsTrainer > 0) {
+      setShowOffConfirm(true);
+      return;
+    }
+    commit(next);
   }
 
   const isOn = settings?.adminsActAsTrainers ?? false;
   const disabled = isLoading || updateMutation.isPending;
+  const upcoming = settings?.currentUserUpcomingLessonsAsTrainer ?? 0;
+  const showSaved = savedAt !== null;
 
   return (
-    <div className="bg-white rounded-xl shadow-sm shadow-gray-100 overflow-hidden mb-6">
-      {/* Section header */}
-      <div className="px-6 py-4 border-b border-gray-100 flex items-center gap-2.5">
-        <div className="w-7 h-7 rounded-lg bg-tennis-green/10 flex items-center justify-center">
-          <SettingsIcon size={14} className="text-tennis-green" />
-        </div>
-        <div>
-          <h2 className="text-sm font-semibold text-gray-800">
-            {t("sectionTitle")}
-          </h2>
-          <p className="text-xs text-gray-400">{t("sectionSubtitle")}</p>
-        </div>
-      </div>
-
-      {/* Toggle row */}
-      <div className="p-5">
-        <label className="flex items-start justify-between gap-4 cursor-pointer">
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-semibold text-gray-800">
-              {t("adminsActAsTrainersLabel")}
-            </p>
-            <p className="text-xs text-gray-500 mt-1 leading-relaxed">
-              {t("adminsActAsTrainersHelp")}
-            </p>
+    <>
+      <div className="bg-white rounded-xl shadow-sm shadow-gray-100 overflow-hidden mb-6">
+        {/* Section header */}
+        <div className="px-6 py-4 border-b border-gray-100 flex items-center justify-between gap-2.5">
+          <div className="flex items-center gap-2.5">
+            <div className="w-7 h-7 rounded-lg bg-tennis-green/10 flex items-center justify-center">
+              <SettingsIcon size={14} className="text-tennis-green" />
+            </div>
+            <div>
+              <h2 className="text-sm font-semibold text-gray-800">
+                {t("sectionTitle")}
+              </h2>
+              <p className="text-xs text-gray-400">{t("sectionSubtitle")}</p>
+            </div>
           </div>
-          <button
-            type="button"
-            role="switch"
-            aria-checked={isOn}
-            disabled={disabled}
-            onClick={() => handleToggleAdminsActAsTrainers(!isOn)}
-            className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors mt-0.5 disabled:opacity-50 disabled:cursor-not-allowed ${
-              isOn ? "bg-tennis-green" : "bg-gray-200"
-            }`}
-          >
-            <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
-                isOn ? "translate-x-6" : "translate-x-1"
-              }`}
-            />
-          </button>
-        </label>
+          {showSaved && (
+            <span className="flex items-center gap-1 text-[11px] font-semibold text-tennis-green animate-in fade-in slide-in-from-right-1">
+              <Check size={12} />
+              {t("saved")}
+            </span>
+          )}
+        </div>
 
-        {updateMutation.isError && (
-          <p className="text-xs text-red-500 mt-3">{t("saveError")}</p>
-        )}
+        {/* Toggle row */}
+        <div className="p-5">
+          <label className="flex items-start justify-between gap-4 cursor-pointer">
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-semibold text-gray-800">
+                {t("adminsActAsTrainersLabel")}
+              </p>
+              <p className="text-xs text-gray-500 mt-1 leading-relaxed">
+                {t("adminsActAsTrainersHelp")}
+              </p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={isOn}
+              disabled={disabled}
+              onClick={handleClick}
+              className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors mt-0.5 disabled:opacity-50 disabled:cursor-not-allowed ${
+                isOn ? "bg-tennis-green" : "bg-gray-200"
+              }`}
+            >
+              <span
+                className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                  isOn ? "translate-x-6" : "translate-x-1"
+                }`}
+              />
+            </button>
+          </label>
+
+          {updateMutation.isError && (
+            <p className="text-xs text-red-500 mt-3">{t("saveError")}</p>
+          )}
+        </div>
       </div>
-    </div>
+
+      <AlertDialog open={showOffConfirm} onOpenChange={setShowOffConfirm}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("toggleOffConfirmTitle")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("toggleOffConfirmBody", { count: upcoming })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("toggleOffCancel")}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                setShowOffConfirm(false);
+                commit(false);
+              }}
+              className="bg-tennis-green hover:bg-tennis-green/90 text-white"
+            >
+              {t("toggleOffConfirm")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/frontend/app/(dashboard)/dashboard/settings/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/settings/page.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/lib/api/tennisClubs";
 import { FieldError } from "@/components/forms/field-error";
 import { inputClass } from "@/lib/styles";
+import { OrganizationSection } from "./organization-section";
 
 // ─── Form Schema ──────────────────────────────────────────────────────────────
 
@@ -150,6 +151,9 @@ export default function SettingsPage() {
           Beheer de basisinstellingen van je organisatie.
         </p>
       </div>
+
+      {/* Organisatie-instellingen */}
+      <OrganizationSection />
 
       {/* Tennisclubs section */}
       <div className="bg-white rounded-xl shadow-sm shadow-gray-100 overflow-hidden">

--- a/frontend/app/(dashboard)/dashboard/trainers/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/trainers/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -24,6 +24,7 @@ import {
   TrainerDto,
 } from "@/lib/api/trainers";
 import { getAxiosErrorMessages } from "@/lib/utils/api-errors";
+import { getAuthUser, type AuthUser } from "@/lib/auth";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -319,8 +320,13 @@ type RemoveDialogState =
 export default function TrainersPage() {
   const [showInviteForm, setShowInviteForm] = useState(false);
   const [removeDialog, setRemoveDialog] = useState<RemoveDialogState>({ type: "none" });
+  const [user, setUser] = useState<AuthUser | null>(null);
   const queryClient = useQueryClient();
   const t = useTranslations("trainers");
+
+  useEffect(() => {
+    setUser(getAuthUser());
+  }, []);
 
   const { data: trainers, isLoading } = useQuery({
     queryKey: ["trainers"],
@@ -432,6 +438,10 @@ export default function TrainersPage() {
             const initials = `${tr.firstName[0] ?? ""}${tr.lastName[0] ?? ""}`.toUpperCase();
             const isInvited = !tr.isActive && tr.invitePending;
             const isDeactivatedState = !tr.isActive && !tr.invitePending;
+            // De eigen admin verschijnt alleen in deze lijst zolang AdminsActAsTrainers
+            // aanstaat in /dashboard/settings. Beheer gebeurt daar, niet via deactivate/remove
+            // (de Admin-rol kun je op de trainerlijst niet wijzigen).
+            const isSelfAdmin = user?.role === "Admin" && tr.id === user?.userId;
             const cap = capacityLabel(tr.currentWeekHoursBooked, tr.weeklyCapacityHours, t);
             const loadPct = tr.weeklyCapacityHours > 0
               ? Math.min(100, Math.round((tr.currentWeekHoursBooked / tr.weeklyCapacityHours) * 100))
@@ -448,7 +458,11 @@ export default function TrainersPage() {
                       <p className="text-[13.5px] font-bold text-ink m-0">
                         {tr.firstName} {tr.lastName}
                       </p>
-                      {isInvited ? (
+                      {isSelfAdmin ? (
+                        <span className="text-[10px] px-2 py-0.5 rounded-full bg-tennis-lime/30 text-tennis-green font-semibold">
+                          {t("adminBadge")}
+                        </span>
+                      ) : isInvited ? (
                         <span className="text-[10px] px-2 py-0.5 rounded-full bg-amber-50 text-amber-700 font-semibold">
                           {t("invitedLabel")}
                         </span>
@@ -501,22 +515,30 @@ export default function TrainersPage() {
                         )}
                       </div>
                       <div className="flex gap-1 justify-end items-end">
-                        <button
-                          onClick={() => deactivateMutation.mutate(tr.id)}
-                          disabled={deactivateMutation.isPending}
-                          title={t("deactivate")}
-                          className="opacity-0 group-hover:opacity-100 p-1.5 rounded text-ink-3 hover:text-amber-500 hover:bg-amber-50 transition-all"
-                        >
-                          <UserX size={14} />
-                        </button>
-                        {tr.lessonSeriesCount === 0 && (
-                          <button
-                            onClick={() => handleRemoveClick(tr)}
-                            title={t("remove")}
-                            className="opacity-0 group-hover:opacity-100 p-1.5 rounded text-ink-3 hover:text-red-500 hover:bg-red-50 transition-all"
-                          >
-                            <Trash2 size={14} />
-                          </button>
+                        {isSelfAdmin ? (
+                          <span className="text-[9.5px] text-ink-3 italic">
+                            {t("manageViaSettings")}
+                          </span>
+                        ) : (
+                          <>
+                            <button
+                              onClick={() => deactivateMutation.mutate(tr.id)}
+                              disabled={deactivateMutation.isPending}
+                              title={t("deactivate")}
+                              className="opacity-0 group-hover:opacity-100 p-1.5 rounded text-ink-3 hover:text-amber-500 hover:bg-amber-50 transition-all"
+                            >
+                              <UserX size={14} />
+                            </button>
+                            {tr.lessonSeriesCount === 0 && (
+                              <button
+                                onClick={() => handleRemoveClick(tr)}
+                                title={t("remove")}
+                                className="opacity-0 group-hover:opacity-100 p-1.5 rounded text-ink-3 hover:text-red-500 hover:bg-red-50 transition-all"
+                              >
+                                <Trash2 size={14} />
+                              </button>
+                            )}
+                          </>
                         )}
                       </div>
                     </div>

--- a/frontend/lib/api/organizationSettings.ts
+++ b/frontend/lib/api/organizationSettings.ts
@@ -2,6 +2,7 @@ import apiClient from "@/lib/api-client";
 
 export interface OrganizationSettingsDto {
   adminsActAsTrainers: boolean;
+  currentUserUpcomingLessonsAsTrainer: number;
 }
 
 export interface UpdateOrganizationSettingsRequest {

--- a/frontend/lib/api/organizationSettings.ts
+++ b/frontend/lib/api/organizationSettings.ts
@@ -1,0 +1,26 @@
+import apiClient from "@/lib/api-client";
+
+export interface OrganizationSettingsDto {
+  adminsActAsTrainers: boolean;
+}
+
+export interface UpdateOrganizationSettingsRequest {
+  adminsActAsTrainers: boolean;
+}
+
+export async function getOrganizationSettings(): Promise<OrganizationSettingsDto> {
+  const { data } = await apiClient.get<OrganizationSettingsDto>(
+    "/organization/settings",
+  );
+  return data;
+}
+
+export async function updateOrganizationSettings(
+  request: UpdateOrganizationSettingsRequest,
+): Promise<OrganizationSettingsDto> {
+  const { data } = await apiClient.put<OrganizationSettingsDto>(
+    "/organization/settings",
+    request,
+  );
+  return data;
+}

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -1,6 +1,7 @@
 const TOKEN_KEY = 'token';
 const USER_KEY = 'auth_user';
 const AUTH_COOKIE = 'has_token';
+const ROLE_COOKIE = 'user_role';
 
 export interface OrganizationMembershipInfo {
   organizationId: string;
@@ -54,17 +55,23 @@ export function getAuthUser(): AuthUser | null {
 export function setAuthUser(user: AuthUser): void {
   if (typeof window === 'undefined') return;
   localStorage.setItem(USER_KEY, JSON.stringify(user));
+  // Spiegel de rol in een cookie zodat de Next-middleware role-based redirects
+  // kan doen zonder localStorage te kunnen lezen. NIET security-kritisch — de
+  // backend blijft de uiteindelijke autoriteit (RequireRole/RequireAuthorization).
+  document.cookie = `${ROLE_COOKIE}=${encodeURIComponent(user.role)}; path=/; SameSite=Lax`;
 }
 
 export function removeAuthUser(): void {
   if (typeof window === 'undefined') return;
   localStorage.removeItem(USER_KEY);
+  document.cookie = `${ROLE_COOKIE}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
 }
 
 export function clearAuth(): void {
   removeToken();
   removeAuthUser();
   document.cookie = `${AUTH_COOKIE}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+  document.cookie = `${ROLE_COOKIE}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
 }
 
 export function isAuthenticated(): boolean {

--- a/frontend/lib/nav-items.ts
+++ b/frontend/lib/nav-items.ts
@@ -51,5 +51,6 @@ export const navItems = [
     href: "/dashboard/settings",
     icon: Settings,
     exact: false,
+    adminOnly: true,
   },
 ];

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -89,8 +89,12 @@
     "sectionSubtitle": "Algemene instellingen voor deze tennisschool",
     "adminsActAsTrainersLabel": "Beheerder telt als trainer",
     "adminsActAsTrainersHelp": "Wanneer ingeschakeld verschijn je als beheerder automatisch in de trainerlijst en kunnen lessen aan jou worden toegewezen. Schakel uit als je puur administratief werkt.",
-    "saveSuccess": "Instellingen opgeslagen",
-    "saveError": "Opslaan mislukt — probeer opnieuw"
+    "saved": "Opgeslagen",
+    "saveError": "Opslaan mislukt — probeer opnieuw",
+    "toggleOffConfirmTitle": "Beheerder uit trainerlijst halen?",
+    "toggleOffConfirmBody": "Je hebt nog {count} openstaande les(sen) aan jezelf toegewezen. Deze blijven gewoon bestaan, maar je kan geen nieuwe lessen meer ontvangen tot je de instelling weer aanzet. Wil je toch doorgaan?",
+    "toggleOffConfirm": "Ja, uitschakelen",
+    "toggleOffCancel": "Annuleren"
   },
   "tennisClubs": {
     "title": "Tennisclubs",
@@ -392,6 +396,8 @@
   },
   "trainers": {
     "title": "Trainers",
+    "adminBadge": "Beheerder",
+    "manageViaSettings": "Beheer via Instellingen",
     "invite": "Uitnodigen",
     "inviteTitle": "Trainer uitnodigen",
     "inviteSent": "Uitnodiging verzonden",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -84,6 +84,14 @@
     "lessons_count": "{count} lesmomenten",
     "per_series": "per reeks"
   },
+  "organizationSettings": {
+    "sectionTitle": "Organisatie",
+    "sectionSubtitle": "Algemene instellingen voor deze tennisschool",
+    "adminsActAsTrainersLabel": "Beheerder telt als trainer",
+    "adminsActAsTrainersHelp": "Wanneer ingeschakeld verschijn je als beheerder automatisch in de trainerlijst en kunnen lessen aan jou worden toegewezen. Schakel uit als je puur administratief werkt.",
+    "saveSuccess": "Instellingen opgeslagen",
+    "saveError": "Opslaan mislukt — probeer opnieuw"
+  },
   "tennisClubs": {
     "title": "Tennisclubs",
     "name": "Naam",

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -9,8 +9,19 @@ const PUBLIC_ROUTES = [
   "/auth/magic",
 ];
 
+// Dashboard-paden die alleen voor Admin toegankelijk zijn. De sidebar verbergt
+// deze al via `adminOnly`, maar deze redirect dekt directe URL-toegang. De backend
+// blijft de uiteindelijke autoriteit (RequireRole("Admin")) — dit is UX, geen security.
+const ADMIN_ONLY_DASHBOARD_PATHS = ["/dashboard/settings", "/dashboard/trainers"];
+
 function isPublicRoute(pathname: string): boolean {
   return PUBLIC_ROUTES.some(
+    (route) => pathname === route || pathname.startsWith(`${route}/`)
+  );
+}
+
+function isAdminOnlyDashboardPath(pathname: string): boolean {
+  return ADMIN_ONLY_DASHBOARD_PATHS.some(
     (route) => pathname === route || pathname.startsWith(`${route}/`)
   );
 }
@@ -23,6 +34,13 @@ export function middleware(request: NextRequest) {
     const loginUrl = new URL("/login", request.url);
     loginUrl.searchParams.set("redirect", pathname);
     return NextResponse.redirect(loginUrl);
+  }
+
+  if (isAdminOnlyDashboardPath(pathname) && hasToken) {
+    const role = request.cookies.get("user_role")?.value;
+    if (role && role !== "Admin") {
+      return NextResponse.redirect(new URL("/dashboard", request.url));
+    }
   }
 
   if (pathname.startsWith("/student/") && !hasToken) {


### PR DESCRIPTION
## Summary
- New `OrganizationSettings` entity (1-1 with `Organization`), designed to grow with future org-wide preferences. First setting: `AdminsActAsTrainers` (default `true`) — controls whether the org admin appears in the trainer list and can be assigned lessons.
- New `GET`/`PUT /organization/settings` endpoints, Admin-only. DTO also returns the current admin's upcoming lesson count so the UI can warn before toggling off.
- Migration creates the table and **backfills a settings row for every existing organization**, preserving historical admin-as-trainer behaviour. `AuthService.RegisterAsync` seeds the row for new orgs.
- `TrainerService.GetTrainersAsync` and `UserLookupService` (IsActiveTrainerAsync + GetOrganizationMembersAsync) include admins only when the setting is on.
- New `/dashboard/settings` "Organisatie" section with toggle, "Opgeslagen" pulse, and confirm dialog when toggling off with lessons assigned.
- The admin's own row in the trainer list now shows a "Beheerder" badge and a "Beheer via Instellingen" hint instead of deactivate/remove buttons (those don't apply to the Admin role).
- `Settings` and `Trainers` nav-items marked `adminOnly`; middleware enforces the same via a new `user_role` cookie (UX redirect, backend `RequireRole` stays authoritative).
- Replaces the per-membership `IsTrainer` approach from the closed PR #102 with a cleaner org-level setting.

## Test plan
- [ ] Backend `dotnet build` + `dotnet test` green (165 tests)
- [ ] Reset + seed end-to-end green: `bash backend/Scripts/reset-db.sh --no-frontend && bash backend/Scripts/seed-demo-data.sh`
- [ ] After login as admin, `/dashboard/trainers` shows the admin with "Beheerder" badge
- [ ] `/dashboard/settings` "Organisatie" toggle off → admin disappears from trainer list; toggle on → admin returns
- [ ] Toggle-off with upcoming lessons triggers confirm dialog with correct count
- [ ] "Opgeslagen" pulse appears after a save
- [ ] Org-switch (Jan to Padel Brugge) → settings are independent per org
- [ ] Trainer-only login (or temporarily set role cookie to "Trainer") → URL `/dashboard/settings` redirects to `/dashboard`