### PR TITLE
fix(dashboard): type-aware inbox redirects to surface the actionable view

### DIFF
--- a/frontend/app/(dashboard)/dashboard/lessons/[id]/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/lessons/[id]/page.tsx
@@ -1312,7 +1312,10 @@ function EnrollmentsSection({ seriesId }: { seriesId: string }) {
   );
 
   return (
-    <div className="bg-white rounded-xl shadow-sm shadow-gray-100 overflow-hidden">
+    <div
+      id="enrollments"
+      className="bg-white rounded-xl shadow-sm shadow-gray-100 overflow-hidden scroll-mt-20"
+    >
       <div className="px-5 py-4 border-b border-gray-100 flex items-center justify-between">
         <div className="flex items-center gap-2.5">
           <h2 className="text-sm font-semibold text-gray-800">

--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -38,7 +38,12 @@ function severityDotColor(severity: string): string {
 }
 
 function inboxItemHref(item: InboxItemDto): string {
-  if (item.refType === "Series") return `/dashboard/lessons/${item.refId}`;
+  if (item.type === "confirmation_pending") {
+    return `/dashboard/lessons/${item.refId}/planning`;
+  }
+  if (item.type === "series_underbooked") {
+    return `/dashboard/lessons/${item.refId}#enrollments`;
+  }
   if (item.refType === "Student") return `/dashboard/lessons/${item.refId}`;
   return `/dashboard/lessons/${item.refId}`;
 }


### PR DESCRIPTION
## Summary
- Inbox items van type `confirmation_pending` linken nu rechtstreeks naar de planning-subpagina (`/dashboard/lessons/{id}/planning`) zodat de trainer meteen de bevestiging kan afhandelen
- Items van type `series_underbooked` linken naar `#enrollments` op de series-detailpagina; de sectie kreeg een anchor + `scroll-mt-20` zodat de sticky header de titel niet bedekt
- Fallback gedrag (overige `refType`-waarden) blijft ongewijzigd

## Test plan
- [ ] Typecheck groen (`bun run typecheck`)
- [ ] Production build groen (`bun run build`) en `/dashboard/lessons/[id]/planning` wordt gegenereerd
- [ ] Inbox: klik op een `confirmation_pending` item → landt op planning-tab
- [ ] Inbox: klik op een `series_underbooked` item → landt op series-detail, scrollt naar Enrollments sectie zonder dat de header de titel afdekt