### PR TITLE
fix(auth): reject invite link reuse after password is set

### DIFF
--- a/backend/CoachOS.API/Endpoints/Auth/ValidateInviteEndpoint.cs
+++ b/backend/CoachOS.API/Endpoints/Auth/ValidateInviteEndpoint.cs
@@ -1,0 +1,26 @@
+using CoachOS.API.Extensions;
+using CoachOS.Application.Auth;
+
+namespace CoachOS.API.Endpoints.Auth;
+
+/// <summary>
+/// Bevestigt of een invite-token nog bruikbaar is. De FE roept dit bij page-load
+/// zodat een reeds geaccepteerde of verlopen link niet langer het wachtwoord-formulier toont.
+/// </summary>
+public class ValidateInviteEndpoint : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/auth/invite/{token}/validate", async (
+            string token,
+            IAuthService authService,
+            CancellationToken ct) =>
+        {
+            var result = await authService.ValidateInviteTokenAsync(token, ct);
+            return result.IsSuccess ? Results.Ok(result.Value) : result.ToErrorResult();
+        })
+        .AllowAnonymous()
+        .RequireRateLimiting("auth")
+        .WithTags("Auth");
+    }
+}

--- a/backend/CoachOS.Application/Auth/DTOs/InviteValidationDto.cs
+++ b/backend/CoachOS.Application/Auth/DTOs/InviteValidationDto.cs
@@ -1,0 +1,8 @@
+namespace CoachOS.Application.Auth.DTOs;
+
+/// <summary>
+/// Resultaat van een invite-token validatie. Bevat enkel velden die de FE nodig
+/// heeft om de welkom-pagina te personaliseren — geen e-mail (anti-enumeration)
+/// en geen membership-details.
+/// </summary>
+public record InviteValidationDto(string FirstName);

--- a/backend/CoachOS.Application/Auth/IAuthService.cs
+++ b/backend/CoachOS.Application/Auth/IAuthService.cs
@@ -54,4 +54,13 @@ public interface IAuthService
         string token,
         string password,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Valideert een invite-token zonder het te consumeren. Gebruikt door de FE
+    /// om bij page-load te checken of de link nog geldig is — voorkomt dat een
+    /// reeds geaccepteerde invite alsnog het formulier toont.
+    /// </summary>
+    Task<Result<InviteValidationDto>> ValidateInviteTokenAsync(
+        string token,
+        CancellationToken cancellationToken = default);
 }

--- a/backend/CoachOS.Infrastructure/Identity/AuthService.cs
+++ b/backend/CoachOS.Infrastructure/Identity/AuthService.cs
@@ -335,6 +335,26 @@ public class AuthService(
         });
     }
 
+    public async Task<Result<InviteValidationDto>> ValidateInviteTokenAsync(
+        string token,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+            return Result<InviteValidationDto>.Fail("Ongeldige uitnodigingslink");
+
+        var hashedToken = HashToken(token);
+        var user = await userManager.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.InviteToken == hashedToken, cancellationToken);
+
+        if (user is null)
+            return Result<InviteValidationDto>.Fail("Ongeldige uitnodigingslink");
+        if (user.InviteTokenExpiry is null || user.InviteTokenExpiry < DateTime.UtcNow)
+            return Result<InviteValidationDto>.Fail("Uitnodigingslink is verlopen");
+
+        return Result<InviteValidationDto>.Ok(new InviteValidationDto(user.FirstName));
+    }
+
     private static string HashToken(string token)
     {
         var bytes = System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(token));

--- a/frontend/app/(auth)/invite/[token]/page.tsx
+++ b/frontend/app/(auth)/invite/[token]/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { use, useState } from "react";
+import { use, useEffect, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
 
-import { acceptInvite } from "@/lib/api/auth";
+import { acceptInvite, validateInvite } from "@/lib/api/auth";
 import { setToken, setAuthUser, setSuperAdminCookie } from "@/lib/auth";
 import { getAxiosErrorMessages } from "@/lib/utils/api-errors";
 import { CourtPattern } from "@/components/ui/court-pattern";
@@ -48,6 +49,33 @@ export default function InvitePage({
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
   const [errors, setErrors] = useState<string[]>([]);
+  const [validationState, setValidationState] = useState<
+    "checking" | "valid" | "invalid"
+  >("checking");
+  const [invalidMessage, setInvalidMessage] = useState<string>(
+    "Deze uitnodigingslink is niet langer geldig."
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        await validateInvite(token);
+        if (!cancelled) setValidationState("valid");
+      } catch (error) {
+        if (cancelled) return;
+        const messages = getAxiosErrorMessages(
+          error,
+          "Deze uitnodigingslink is niet langer geldig."
+        );
+        setInvalidMessage(messages[0] ?? "Deze uitnodigingslink is niet langer geldig.");
+        setValidationState("invalid");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
 
   const form = useForm<FormValues>({
     resolver: zodResolver(schema),
@@ -152,8 +180,32 @@ export default function InvitePage({
             </p>
           </div>
 
+          {validationState === "checking" && (
+            <div className="flex items-center justify-center py-10">
+              <Spinner />
+            </div>
+          )}
+
+          {validationState === "invalid" && (
+            <div className="space-y-4">
+              <div className="px-4 py-3 rounded-lg bg-red-50 border border-red-100">
+                <p className="text-red-600 text-sm">{invalidMessage}</p>
+              </div>
+              <p className="text-gray-500 text-sm">
+                Deze link is verlopen of al gebruikt. Log in met je wachtwoord of
+                vraag een nieuwe uitnodiging aan.
+              </p>
+              <Link
+                href="/login"
+                className="inline-flex items-center justify-center w-full h-11 bg-tennis-green hover:bg-tennis-green/90 text-white font-semibold rounded-lg transition-colors"
+              >
+                Naar inloggen
+              </Link>
+            </div>
+          )}
+
           {/* Error banner */}
-          {errors.length > 0 && (
+          {validationState === "valid" && errors.length > 0 && (
             <div className="mb-6 px-4 py-3 rounded-lg bg-red-50 border border-red-100">
               {errors.map((err, i) => (
                 <p key={i} className="text-red-600 text-sm">
@@ -163,6 +215,7 @@ export default function InvitePage({
             </div>
           )}
 
+          {validationState === "valid" && (
           <Form {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
               <FormField
@@ -223,6 +276,7 @@ export default function InvitePage({
               </Button>
             </form>
           </Form>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/lib/api/auth.ts
+++ b/frontend/lib/api/auth.ts
@@ -30,6 +30,17 @@ export async function acceptInvite(request: AcceptInviteRequest): Promise<AuthRe
   return data;
 }
 
+export interface InviteValidation {
+  firstName: string;
+}
+
+export async function validateInvite(token: string): Promise<InviteValidation> {
+  const { data } = await apiClient.get<InviteValidation>(
+    `/auth/invite/${encodeURIComponent(token)}/validate`
+  );
+  return data;
+}
+
 export interface RegisterStudentRequest {
   firstName: string;
   lastName: string;


### PR DESCRIPTION
## Summary
- Add `ValidateInviteTokenAsync` + GET `/auth/invite/{token}/validate` (anonymous, rate-limited)
- Invite page now validates the token on mount and shows an "expired / already used" state with a link to `/login` when the invite was already accepted
- Previously the password form rendered regardless of token state — only the POST would fail

## Test plan
- [ ] Invite a new admin via super-admin, open the link, set a password
- [ ] Re-open the same invite link → expect "deze link is verlopen of al gebruikt" + "Naar inloggen" button (no password form)
- [ ] Open an invalid `/invite/<random>` link → same expired state
- [ ] Open a fresh invite link → password form renders normally