### PR TITLE
fix(dashboard): include admin in active trainer count when AdminsActAsTrainers is on

### DIFF
--- a/backend/CoachOS.Domain/Interfaces/IUserLookupService.cs
+++ b/backend/CoachOS.Domain/Interfaces/IUserLookupService.cs
@@ -8,9 +8,9 @@ public interface IUserLookupService
     Task<bool> IsActiveTrainerAsync(Guid trainerId, Guid organizationId, CancellationToken ct = default);
 
     /// <summary>
-    /// Telt actieve memberships in deze organisatie met uitsluitend rol Trainer.
-    /// Admins tellen hier NIET mee, ook al kunnen ze zelf lesgeven — voor dashboard-
-    /// statistieken willen we enkel de "echte" trainers.
+    /// Telt actieve trainer-memberships in deze organisatie.
+    /// Admins tellen mee wanneer AdminsActAsTrainers aan staat, zodat het dashboard-
+    /// cijfer overeenkomt met de trainerslijst die aan de admin getoond wordt.
     /// </summary>
     Task<int> CountActiveTrainersAsync(Guid organizationId, CancellationToken ct = default);
     Task<Dictionary<Guid, (string FullName, string Email)>> GetUserNamesAndEmailsByIdsAsync(IEnumerable<Guid> ids, CancellationToken ct = default);

--- a/backend/CoachOS.Infrastructure/Identity/UserLookupService.cs
+++ b/backend/CoachOS.Infrastructure/Identity/UserLookupService.cs
@@ -76,10 +76,12 @@ public class UserLookupService(
 
     public async Task<int> CountActiveTrainersAsync(Guid organizationId, CancellationToken ct = default)
     {
+        var includeAdmins = await AdminsActAsTrainersAsync(organizationId, ct);
+
         return await context.OrganizationMemberships
             .AsNoTracking()
             .CountAsync(m => m.OrganizationId == organizationId
-                && m.Role == UserRole.Trainer
+                && (m.Role == UserRole.Trainer || (includeAdmins && m.Role == UserRole.Admin))
                 && m.IsActive, ct);
     }
 


### PR DESCRIPTION
## Summary
- Dashboard showed `0` active trainers when the org admin was the only one teaching, even though they appeared in the trainers list.
- `CountActiveTrainersAsync` hard-filtered `Role == Trainer` and ignored the `AdminsActAsTrainers` org setting, diverging from `IsActiveTrainerAsync` and `GetOrganizationMembersAsync` which already respect it.
- Fix: read the setting and count admins as trainers when the flag is on, matching the trainer list the admin actually sees.

## Test plan
- [ ] `dotnet build CoachOS.slnx` — green (verified locally)
- [ ] Fresh org with admin only, `AdminsActAsTrainers = true` → dashboard shows 1 trainer
- [ ] Org with `AdminsActAsTrainers = false` → admin not counted (only real trainers)
- [ ] Org with mixed admin + trainer memberships → count matches the trainer list length