### PR TITLE
fix(security): sanitize HTML/script input across validators

### DIFF
--- a/backend/CoachOS.Application/Auth/Validators/RegisterRequestValidator.cs
+++ b/backend/CoachOS.Application/Auth/Validators/RegisterRequestValidator.cs
@@ -1,4 +1,5 @@
 using CoachOS.Application.Auth.DTOs;
+using CoachOS.Application.Common;
 using FluentValidation;
 
 namespace CoachOS.Application.Auth.Validators;
@@ -9,15 +10,18 @@ public class RegisterRequestValidator : AbstractValidator<RegisterRequest>
     {
         RuleFor(x => x.OrganizationName)
             .NotEmpty().WithMessage("Naam organisatie is verplicht")
-            .MaximumLength(200).WithMessage("Naam organisatie mag maximaal 200 karakters zijn");
+            .MaximumLength(200).WithMessage("Naam organisatie mag maximaal 200 karakters zijn")
+            .Must(InputSanitizer.IsFreeOfHtml).WithMessage("Naam organisatie mag geen HTML of scripttekens bevatten");
 
         RuleFor(x => x.FirstName)
             .NotEmpty().WithMessage("Voornaam is verplicht")
-            .MaximumLength(100).WithMessage("Voornaam mag maximaal 100 karakters zijn");
+            .MaximumLength(100).WithMessage("Voornaam mag maximaal 100 karakters zijn")
+            .Must(InputSanitizer.IsFreeOfHtml).WithMessage("Voornaam mag geen HTML of scripttekens bevatten");
 
         RuleFor(x => x.LastName)
             .NotEmpty().WithMessage("Achternaam is verplicht")
-            .MaximumLength(100).WithMessage("Achternaam mag maximaal 100 karakters zijn");
+            .MaximumLength(100).WithMessage("Achternaam mag maximaal 100 karakters zijn")
+            .Must(InputSanitizer.IsFreeOfHtml).WithMessage("Achternaam mag geen HTML of scripttekens bevatten");
 
         RuleFor(x => x.Email)
             .NotEmpty().WithMessage("E-mailadres is verplicht")

--- a/backend/CoachOS.Application/Common/InputSanitizer.cs
+++ b/backend/CoachOS.Application/Common/InputSanitizer.cs
@@ -1,0 +1,17 @@
+using System.Text.RegularExpressions;
+
+namespace CoachOS.Application.Common;
+
+public static partial class InputSanitizer
+{
+    [GeneratedRegex(@"[<>]|&#|javascript:|on\w+\s*=", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex HtmlOrScriptRegex();
+
+    public static bool IsFreeOfHtml(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return true;
+        return !HtmlOrScriptRegex().IsMatch(value);
+    }
+
+    public static bool IsFreeOfHtmlNullable(string? value) => IsFreeOfHtml(value);
+}

--- a/backend/CoachOS.Application/Enrollments/Validators/SubmitEnrollmentRequestValidator.cs
+++ b/backend/CoachOS.Application/Enrollments/Validators/SubmitEnrollmentRequestValidator.cs
@@ -1,4 +1,5 @@
 using CoachOS.Application.Enrollments.DTOs;
+using CoachOS.Application.Common;
 using FluentValidation;
 
 namespace CoachOS.Application.Enrollments.Validators;
@@ -9,11 +10,18 @@ public class SubmitEnrollmentRequestValidator : AbstractValidator<SubmitEnrollme
     {
         RuleFor(x => x.StudentName)
             .NotEmpty().WithMessage("Naam is verplicht")
-            .MaximumLength(200).WithMessage("Naam mag maximaal 200 karakters zijn");
+            .MaximumLength(200).WithMessage("Naam mag maximaal 200 karakters zijn")
+            .Must(InputSanitizer.IsFreeOfHtml).WithMessage("Naam mag geen HTML of scripttekens bevatten");
 
         RuleFor(x => x.StudentEmail)
             .NotEmpty().WithMessage("E-mailadres is verplicht")
+            .MaximumLength(254).WithMessage("E-mailadres is te lang")
             .EmailAddress().WithMessage("Ongeldig e-mailadres");
+
+        RuleFor(x => x.StudentPhone)
+            .MaximumLength(30).WithMessage("Telefoonnummer is te lang")
+            .Must(InputSanitizer.IsFreeOfHtmlNullable).WithMessage("Telefoonnummer mag geen HTML of scripttekens bevatten")
+            .When(x => !string.IsNullOrEmpty(x.StudentPhone));
 
         RuleForEach(x => x.Responses).ChildRules(r =>
         {
@@ -48,11 +56,18 @@ public class SubmitEnrollmentRequestValidator : AbstractValidator<SubmitEnrollme
             {
                 m.RuleFor(v => v.StudentName)
                     .NotEmpty().WithMessage("Naam is verplicht")
-                    .MaximumLength(200).WithMessage("Naam mag maximaal 200 karakters zijn");
+                    .MaximumLength(200).WithMessage("Naam mag maximaal 200 karakters zijn")
+                    .Must(InputSanitizer.IsFreeOfHtml).WithMessage("Naam mag geen HTML of scripttekens bevatten");
 
                 m.RuleFor(v => v.StudentEmail)
                     .NotEmpty().WithMessage("E-mailadres is verplicht")
+                    .MaximumLength(254).WithMessage("E-mailadres is te lang")
                     .EmailAddress().WithMessage("Ongeldig e-mailadres");
+
+                m.RuleFor(v => v.StudentPhone)
+                    .MaximumLength(30).WithMessage("Telefoonnummer is te lang")
+                    .Must(InputSanitizer.IsFreeOfHtmlNullable).WithMessage("Telefoonnummer mag geen HTML of scripttekens bevatten")
+                    .When(v => !string.IsNullOrEmpty(v.StudentPhone));
             });
         });
     }

--- a/backend/CoachOS.Application/LessonSerie/Validators/CreateLessonSerieRequestValidator.cs
+++ b/backend/CoachOS.Application/LessonSerie/Validators/CreateLessonSerieRequestValidator.cs
@@ -1,3 +1,4 @@
+using CoachOS.Application.Common;
 using CoachOS.Application.LessonSerie.DTOs;
 using FluentValidation;
 
@@ -12,17 +13,20 @@ public class CreateLessonSerieRequestValidator : AbstractValidator<CreateLessonS
 
         RuleFor(x => x.Name)
             .NotEmpty().WithMessage("Naam is verplicht.")
-            .MaximumLength(200).WithMessage("Naam mag maximaal 200 karakters zijn.");
+            .MaximumLength(100).WithMessage("Naam mag maximaal 100 karakters zijn.")
+            .Must(InputSanitizer.IsFreeOfHtml).WithMessage("Naam mag geen HTML of scripttekens bevatten.");
 
         RuleFor(x => x.Level)
             .InclusiveBetween(1, 5).WithMessage("Niveau moet tussen 1 en 5 liggen.")
             .When(x => x.Level.HasValue);
 
         RuleFor(x => x.Price)
-            .GreaterThanOrEqualTo(0).WithMessage("Prijs mag niet negatief zijn.");
+            .GreaterThanOrEqualTo(0).WithMessage("Prijs mag niet negatief zijn.")
+            .LessThanOrEqualTo(100000m).WithMessage("Prijs is onrealistisch hoog.");
 
         RuleFor(x => x.MaxRegistrations)
             .GreaterThan(0).WithMessage("Maximum aantal inschrijvingen moet groter dan 0 zijn.")
+            .LessThanOrEqualTo(500).WithMessage("Maximum aantal inschrijvingen mag niet meer dan 500 zijn.")
             .When(x => x.MaxRegistrations.HasValue);
 
         RuleFor(x => x.StartDate)

--- a/backend/CoachOS.Application/LessonSerie/Validators/UpdateLessonSerieRequestValidator.cs
+++ b/backend/CoachOS.Application/LessonSerie/Validators/UpdateLessonSerieRequestValidator.cs
@@ -1,3 +1,4 @@
+using CoachOS.Application.Common;
 using CoachOS.Application.LessonSerie.DTOs;
 using FluentValidation;
 
@@ -9,17 +10,20 @@ public class UpdateLessonSerieRequestValidator : AbstractValidator<UpdateLessonS
     {
         RuleFor(x => x.Name)
             .NotEmpty().WithMessage("Naam is verplicht.")
-            .MaximumLength(200).WithMessage("Naam mag maximaal 200 karakters zijn.");
+            .MaximumLength(100).WithMessage("Naam mag maximaal 100 karakters zijn.")
+            .Must(InputSanitizer.IsFreeOfHtml).WithMessage("Naam mag geen HTML of scripttekens bevatten.");
 
         RuleFor(x => x.Level)
             .InclusiveBetween(1, 5).WithMessage("Niveau moet tussen 1 en 5 liggen.")
             .When(x => x.Level.HasValue);
 
         RuleFor(x => x.Price)
-            .GreaterThanOrEqualTo(0).WithMessage("Prijs mag niet negatief zijn.");
+            .GreaterThanOrEqualTo(0).WithMessage("Prijs mag niet negatief zijn.")
+            .LessThanOrEqualTo(100000m).WithMessage("Prijs is onrealistisch hoog.");
 
         RuleFor(x => x.MaxRegistrations)
             .GreaterThan(0).WithMessage("Maximum aantal inschrijvingen moet groter dan 0 zijn.")
+            .LessThanOrEqualTo(500).WithMessage("Maximum aantal inschrijvingen mag niet meer dan 500 zijn.")
             .When(x => x.MaxRegistrations.HasValue);
 
         RuleFor(x => x.RegistrationDeadline)

--- a/backend/CoachOS.Application/TennisClubs/Validators/CreateTennisClubRequestValidator.cs
+++ b/backend/CoachOS.Application/TennisClubs/Validators/CreateTennisClubRequestValidator.cs
@@ -1,3 +1,4 @@
+using CoachOS.Application.Common;
 using CoachOS.Application.TennisClubs.DTOs;
 using FluentValidation;
 
@@ -9,10 +10,12 @@ public class CreateTennisClubRequestValidator : AbstractValidator<CreateTennisCl
     {
         RuleFor(x => x.Name)
             .NotEmpty().WithMessage("Naam is verplicht.")
-            .MaximumLength(200).WithMessage("Naam mag maximaal 200 karakters zijn.");
+            .MaximumLength(200).WithMessage("Naam mag maximaal 200 karakters zijn.")
+            .Must(InputSanitizer.IsFreeOfHtml).WithMessage("Naam mag geen HTML of scripttekens bevatten.");
 
         RuleFor(x => x.Address)
             .NotEmpty().WithMessage("Adres is verplicht.")
-            .MaximumLength(500).WithMessage("Adres mag maximaal 500 karakters zijn.");
+            .MaximumLength(500).WithMessage("Adres mag maximaal 500 karakters zijn.")
+            .Must(InputSanitizer.IsFreeOfHtml).WithMessage("Adres mag geen HTML of scripttekens bevatten.");
     }
 }

--- a/backend/CoachOS.Application/TennisClubs/Validators/UpdateTennisClubRequestValidator.cs
+++ b/backend/CoachOS.Application/TennisClubs/Validators/UpdateTennisClubRequestValidator.cs
@@ -1,3 +1,4 @@
+using CoachOS.Application.Common;
 using CoachOS.Application.TennisClubs.DTOs;
 using FluentValidation;
 
@@ -9,10 +10,12 @@ public class UpdateTennisClubRequestValidator : AbstractValidator<UpdateTennisCl
     {
         RuleFor(x => x.Name)
             .MaximumLength(200).WithMessage("Naam mag maximaal 200 karakters zijn.")
+            .Must(InputSanitizer.IsFreeOfHtmlNullable).WithMessage("Naam mag geen HTML of scripttekens bevatten.")
             .When(x => x.Name is not null);
 
         RuleFor(x => x.Address)
             .MaximumLength(500).WithMessage("Adres mag maximaal 500 karakters zijn.")
+            .Must(InputSanitizer.IsFreeOfHtmlNullable).WithMessage("Adres mag geen HTML of scripttekens bevatten.")
             .When(x => x.Address is not null);
     }
 }

--- a/backend/CoachOS.Application/Trainers/Validators/InviteTrainerRequestValidator.cs
+++ b/backend/CoachOS.Application/Trainers/Validators/InviteTrainerRequestValidator.cs
@@ -1,3 +1,4 @@
+using CoachOS.Application.Common;
 using CoachOS.Application.Trainers.DTOs;
 using FluentValidation;
 
@@ -9,14 +10,17 @@ public class InviteTrainerRequestValidator : AbstractValidator<InviteTrainerRequ
     {
         RuleFor(x => x.FirstName)
             .NotEmpty().WithMessage("Voornaam is verplicht")
-            .MaximumLength(100).WithMessage("Voornaam mag maximaal 100 karakters zijn");
+            .MaximumLength(100).WithMessage("Voornaam mag maximaal 100 karakters zijn")
+            .Must(InputSanitizer.IsFreeOfHtml).WithMessage("Voornaam mag geen HTML of scripttekens bevatten");
 
         RuleFor(x => x.LastName)
             .NotEmpty().WithMessage("Achternaam is verplicht")
-            .MaximumLength(100).WithMessage("Achternaam mag maximaal 100 karakters zijn");
+            .MaximumLength(100).WithMessage("Achternaam mag maximaal 100 karakters zijn")
+            .Must(InputSanitizer.IsFreeOfHtml).WithMessage("Achternaam mag geen HTML of scripttekens bevatten");
 
         RuleFor(x => x.Email)
             .NotEmpty().WithMessage("E-mail is verplicht")
+            .MaximumLength(254).WithMessage("E-mailadres is te lang")
             .EmailAddress().WithMessage("Ongeldig e-mailadres");
     }
 }


### PR DESCRIPTION
## Summary
- Adds `InputSanitizer` helper that rejects HTML tags (`<`, `>`), HTML entities (`&#`), `javascript:` URIs, and `on*` event handlers
- Applied to all user-controlled text fields: register, trainer invite, tennis club, lesson serie, and enrollment forms
- Tightens email max length (254) and adds phone-number length/sanitization on enrollment

## Why
React escapes text content in the browser, so XSS payloads stored in DB don't fire in the SPA — but the same strings feed MJML email templates and could XSS recipients. This closes the gap at the validator layer.

## Test plan
- [ ] `dotnet test CoachOS.slnx` passes
- [ ] POST trainer invite with `firstName=<script>` returns 400
- [ ] POST tennisclub with `name=<script>` returns 400
- [ ] POST enrollment with valid Dutch names with accents (à, ë, ï) still succeeds

Refs #112 (Bug #6)