### PR TITLE
fix(api): return correct HTTP status codes from enrollment endpoint

### DIFF
--- a/backend/CoachOS.API/Extensions/ResultExtensions.cs
+++ b/backend/CoachOS.API/Extensions/ResultExtensions.cs
@@ -29,7 +29,8 @@ public static class ResultExtensions
             ErrorCodes.NotFound => StatusCodes.Status404NotFound,
             ErrorCodes.Unauthorized => StatusCodes.Status401Unauthorized,
             ErrorCodes.Forbidden => StatusCodes.Status403Forbidden,
-            ErrorCodes.Conflict => StatusCodes.Status400BadRequest,
+            ErrorCodes.Conflict => StatusCodes.Status409Conflict,
+            ErrorCodes.Unexpected => StatusCodes.Status500InternalServerError,
             _ => StatusCodes.Status400BadRequest,
         };
     }

--- a/backend/CoachOS.Application/Enrollments/EnrollmentService.cs
+++ b/backend/CoachOS.Application/Enrollments/EnrollmentService.cs
@@ -241,9 +241,9 @@ public class EnrollmentService(
         //    met de insert, anders kunnen twee parallelle submitters beide de check passeren
         //    en samen MaxRegistrations overschrijden of een duplicate email creëren.
         Enrollment enrollment;
-        await enrollmentRepo.BeginTransactionAsync(IsolationLevel.Serializable, ct);
         try
         {
+            await enrollmentRepo.BeginTransactionAsync(IsolationLevel.Serializable, ct);
             // 6. Capacity check INSIDE transaction (accounts for group size)
             if (series.MaxRegistrations.HasValue)
             {


### PR DESCRIPTION
## Summary
- Maps `ErrorCodes.Conflict` to HTTP 409 (was 400)
- Maps `ErrorCodes.Unexpected` to HTTP 500 explicitly (was falling through to 400)
- Moves `BeginTransactionAsync` inside the try/catch in `EnrollmentService.SubmitEnrollmentAsync`

## Why
The public enrollment endpoint returned HTTP 500 on business errors that should have been 4xx. Duplicate emails should be 409; with the transaction-begin outside the try block, transient DB failures bypassed `Result<T>` and bubbled up to the global exception handler as 500s.

## Test plan
- [ ] `dotnet test CoachOS.slnx` passes
- [ ] POST duplicate enrollment returns 409 (not 500)
- [ ] POST with capacity-full series returns 409
- [ ] POST with invalid form-field ID returns 400

Refs #112 (Bug #11)