### PR TITLE
fix(tennisclubs): enforce unique name per organization

### DIFF
--- a/backend/CoachOS.Application/TennisClubs/TennisClubService.cs
+++ b/backend/CoachOS.Application/TennisClubs/TennisClubService.cs
@@ -27,6 +27,10 @@ public class TennisClubService(
     public async Task<Result<Guid>> CreateAsync(
         Guid organizationId, CreateTennisClubRequest request, CancellationToken ct = default)
     {
+        var nameTaken = await tennisClubRepo.NameExistsAsync(request.Name, organizationId, null, ct);
+        if (nameTaken)
+            return Result<Guid>.Fail(new Error(ErrorCodes.Conflict, "Er bestaat al een tennisclub met deze naam."));
+
         TennisClub club = new()
         {
             OrganizationId = organizationId,
@@ -49,7 +53,13 @@ public class TennisClubService(
             return Result<TennisClubDto>.Fail(new Error(ErrorCodes.NotFound, "Tennisclub niet gevonden."));
 
         if (request.Name is not null)
+        {
+            var nameTaken = await tennisClubRepo.NameExistsAsync(request.Name, organizationId, id, ct);
+            if (nameTaken)
+                return Result<TennisClubDto>.Fail(new Error(ErrorCodes.Conflict, "Er bestaat al een tennisclub met deze naam."));
+
             club.Name = request.Name;
+        }
 
         if (request.Address is not null)
             club.Address = request.Address;

--- a/backend/CoachOS.Domain/Interfaces/ITennisClubRepository.cs
+++ b/backend/CoachOS.Domain/Interfaces/ITennisClubRepository.cs
@@ -9,5 +9,6 @@ public interface ITennisClubRepository
     Task AddAsync(TennisClub club, CancellationToken ct = default);
     Task DeleteAsync(TennisClub club, CancellationToken ct = default);
     Task<bool> ExistsAsync(Guid id, Guid organizationId, CancellationToken ct = default);
+    Task<bool> NameExistsAsync(string name, Guid organizationId, Guid? excludeId, CancellationToken ct = default);
     Task SaveChangesAsync(CancellationToken ct = default);
 }

--- a/backend/CoachOS.Infrastructure/Migrations/20260520052751_AddTennisClubUniqueNameIndex.Designer.cs
+++ b/backend/CoachOS.Infrastructure/Migrations/20260520052751_AddTennisClubUniqueNameIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CoachOS.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CoachOS.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260520052751_AddTennisClubUniqueNameIndex")]
+    partial class AddTennisClubUniqueNameIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/CoachOS.Infrastructure/Migrations/20260520052751_AddTennisClubUniqueNameIndex.cs
+++ b/backend/CoachOS.Infrastructure/Migrations/20260520052751_AddTennisClubUniqueNameIndex.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CoachOS.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTennisClubUniqueNameIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_TennisClubs_OrganizationId_Name",
+                table: "TennisClubs",
+                columns: new[] { "OrganizationId", "Name" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_TennisClubs_OrganizationId_Name",
+                table: "TennisClubs");
+        }
+    }
+}

--- a/backend/CoachOS.Infrastructure/Persistence/Configurations/TennisClubConfiguration.cs
+++ b/backend/CoachOS.Infrastructure/Persistence/Configurations/TennisClubConfiguration.cs
@@ -24,5 +24,9 @@ public class TennisClubConfiguration : IEntityTypeConfiguration<TennisClub>
             .OnDelete(DeleteBehavior.Restrict);
 
         builder.HasIndex(tc => tc.OrganizationId);
+
+        builder.HasIndex(tc => new { tc.OrganizationId, tc.Name })
+            .IsUnique()
+            .HasDatabaseName("IX_TennisClubs_OrganizationId_Name");
     }
 }

--- a/backend/CoachOS.Infrastructure/Repositories/TennisClubRepository.cs
+++ b/backend/CoachOS.Infrastructure/Repositories/TennisClubRepository.cs
@@ -45,4 +45,15 @@ public class TennisClubRepository(ApplicationDbContext context) : ITennisClubRep
             .AsNoTracking()
             .AnyAsync(tc => tc.Id == id && tc.OrganizationId == organizationId, ct);
     }
+
+    public async Task<bool> NameExistsAsync(string name, Guid organizationId, Guid? excludeId, CancellationToken ct = default)
+    {
+        var normalized = name.Trim().ToLower();
+        return await context.TennisClubs
+            .AsNoTracking()
+            .AnyAsync(tc =>
+                tc.OrganizationId == organizationId &&
+                tc.Name.ToLower() == normalized &&
+                (!excludeId.HasValue || tc.Id != excludeId.Value), ct);
+    }
 }

--- a/backend/CoachOS.Tests/Services/TennisClubServiceTests.cs
+++ b/backend/CoachOS.Tests/Services/TennisClubServiceTests.cs
@@ -86,6 +86,10 @@ public class TennisClubServiceTests
         };
 
         _tennisClubRepo
+            .Setup(r => r.NameExistsAsync(request.Name, OrgId, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _tennisClubRepo
             .Setup(r => r.AddAsync(It.IsAny<TennisClub>(), It.IsAny<CancellationToken>()))
             .Callback<TennisClub, CancellationToken>((c, _) => c.Id = Guid.NewGuid())
             .Returns(Task.CompletedTask);
@@ -99,6 +103,26 @@ public class TennisClubServiceTests
                 It.Is<TennisClub>(c => c.Name == "TC Nieuwe Club" && c.OrganizationId == OrgId),
                 It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    [Test]
+    public async Task CreateAsync_ReturnsConflict_WhenNameAlreadyExists()
+    {
+        CreateTennisClubRequest request = new()
+        {
+            Name = "TC De Aces",
+            Address = "Nieuwstraat 5",
+        };
+
+        _tennisClubRepo
+            .Setup(r => r.NameExistsAsync(request.Name, OrgId, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await _service.CreateAsync(OrgId, request);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainSingle(e => e.Code == ErrorCodes.Conflict);
+        _tennisClubRepo.Verify(r => r.AddAsync(It.IsAny<TennisClub>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     // ── DeleteAsync ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds `NameExistsAsync` to `ITennisClubRepository` (case-insensitive, optional self-exclusion)
- Adds unique index on `(OrganizationId, Name)` via new migration `AddTennisClubUniqueNameIndex`
- Checks for duplicate names in `TennisClubService.CreateAsync` / `UpdateAsync` → returns HTTP 409 with Dutch error message
- Adds unit tests for the new behavior

## Why
Admins could accidentally create duplicate tennis clubs (the QA report shows POST /tennisclubs returning 200 + new GUID even when the name already existed).

## Test plan
- [ ] `dotnet test CoachOS.slnx` passes
- [ ] `bash Scripts/reset-db.sh && bash Scripts/seed-demo-data.sh` succeeds (migration applies cleanly)
- [ ] POST duplicate club name returns 409
- [ ] PUT same name on same club still succeeds (self-exclusion)

Refs #112 (Bug #12)