### PR TITLE
fix(wizard): inline validation and limits on lesson series step 1

### DIFF
--- a/frontend/app/(dashboard)/dashboard/lessons/new/_components/step-1-basisinfo.tsx
+++ b/frontend/app/(dashboard)/dashboard/lessons/new/_components/step-1-basisinfo.tsx
@@ -21,12 +21,24 @@ import type { Step1Data } from "../_types";
 
 const schema = z
   .object({
-    name: z.string().min(1, "Naam is verplicht").max(200),
-    price: z.number().min(0, "Prijs mag niet negatief zijn"),
+    name: z
+      .string()
+      .min(1, "Naam is verplicht")
+      .max(100, "Naam mag maximaal 100 karakters zijn")
+      .refine((v) => !/[<>]|&#|javascript:|on\w+\s*=/i.test(v), {
+        message: "Naam mag geen HTML of scripttekens bevatten",
+      }),
+    price: z
+      .number({ message: "Prijs is verplicht" })
+      .min(0, "Prijs mag niet negatief zijn")
+      .max(100000, "Prijs is onrealistisch hoog"),
     tennisClubId: z.string().min(1, "Tennisclub is verplicht"),
     startDate: z.string().min(1, "Startdatum is verplicht"),
     endDate: z.string().min(1, "Einddatum is verplicht"),
-    maxRegistrations: z.number().min(1, "Minimaal 1 inschrijving toestaan"),
+    maxRegistrations: z
+      .number({ message: "Maximum inschrijvingen is verplicht" })
+      .min(1, "Minimaal 1 inschrijving toestaan")
+      .max(500, "Maximum is 500 inschrijvingen"),
     registrationDeadline: z.string().min(1, "Inschrijfdeadline is verplicht"),
   })
   .refine((d) => !d.startDate || !d.endDate || d.endDate >= d.startDate, {
@@ -81,6 +93,7 @@ export function Step1Basisinfo({ defaultValues, onNext }: Step1Props) {
     formState: { errors },
   } = useForm<FormValues>({
     resolver: zodResolver(schema),
+    mode: "onBlur",
     defaultValues: defaultValues ?? { price: 0, maxRegistrations: 0 },
   });
 
@@ -93,6 +106,7 @@ export function Step1Basisinfo({ defaultValues, onNext }: Step1Props) {
           <input
             {...register("name")}
             type="text"
+            maxLength={100}
             placeholder={t("namePlaceholder")}
             className={inputClass}
           />
@@ -124,6 +138,7 @@ export function Step1Basisinfo({ defaultValues, onNext }: Step1Props) {
             {...register("maxRegistrations", { valueAsNumber: true })}
             type="number"
             min={1}
+            max={500}
             className={inputClass}
           />
           <FieldError message={errors.maxRegistrations?.message} />


### PR DESCRIPTION
## Summary
- Switches `react-hook-form` to `mode: "onBlur"` so the wizard validates per field as the user moves on, instead of only on submit
- Adds `maxLength={100}` + Zod `.max(100)` on the lesson series name and rejects HTML/script characters client-side
- Adds `max={500}` on "Max. inschrijvingen" and Zod limit to match the server validator
- Adds an upper bound on the price field (100 000)

## Why
Step 1 previously only validated on submit, leaving the name field without "required" feedback. The max-registrations and price fields accepted unrealistic values (999999 etc.).

## Test plan
- [ ] Click "Volgende" with empty name → inline error appears under name field
- [ ] Type 150-char name → input truncates at 100
- [ ] Type `<script>` in name → onBlur shows "Naam mag geen HTML of scripttekens bevatten"
- [ ] Type 999 in max-inschrijvingen → shows "Maximum is 500 inschrijvingen"

Refs #112 (Bugs #3, #4, #5)