### PR TITLE
fix(ui): localized 404, hydration, planning labels, pluralization

### DIFF
--- a/frontend/app/(dashboard)/dashboard/lessons/[id]/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/lessons/[id]/page.tsx
@@ -70,7 +70,7 @@ import { FieldError } from "@/components/forms/field-error";
 import { DatePicker } from "@/components/ui/date-picker";
 import { NativeSelect } from "@/components/ui/native-select";
 import { inputClass } from "@/lib/styles";
-import { formatDateShort } from "@/lib/date-utils";
+import { formatDateShort, formatDateNL } from "@/lib/date-utils";
 import { enrollmentStatusStyles } from "@/lib/status-styles";
 import { Badge } from "@/components/ui/badge";
 
@@ -758,10 +758,20 @@ function LessonWeekView({
   trainers: TrainerDto[];
   seriesId: string;
 }) {
-  const [weekIndex, setWeekIndex] = useState(0);
+  const weeks = computeWeeks(startDate, endDate);
+  const initialWeekIndex = (() => {
+    if (lessons.length === 0) return 0;
+    const firstLessonDate = lessons
+      .map((l) => l.date)
+      .sort()[0];
+    const idx = weeks.findIndex(
+      (w) => firstLessonDate >= w.startDate && firstLessonDate <= w.endDate,
+    );
+    return idx === -1 ? 0 : idx;
+  })();
+  const [weekIndex, setWeekIndex] = useState(initialWeekIndex);
   const [editingLesson, setEditingLesson] = useState<LessonDto | null>(null);
   const queryClient = useQueryClient();
-  const weeks = computeWeeks(startDate, endDate);
   const currentWeek = weeks[weekIndex];
 
   if (!currentWeek) return null;
@@ -1479,7 +1489,7 @@ export default function LessonSeriesDetailPage({
                     </span>
                     <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-[#F5F4F1] text-xs text-gray-600">
                       <CalendarDays size={11} className="text-tennis-green" />
-                      {series.startDate} – {series.endDate}
+                      {formatDateNL(series.startDate)} – {formatDateNL(series.endDate)}
                     </span>
                     {series.tennisClubName && (
                       <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-[#F5F4F1] text-xs text-gray-600">

--- a/frontend/app/(dashboard)/dashboard/lessons/[id]/planning/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/lessons/[id]/planning/page.tsx
@@ -466,8 +466,9 @@ export default function PlanningPage({
           {t("legendAutoGrouped")}
         </div>
         <div className="ml-auto text-xs text-gray-400">
-          {totalEnrollments} {t("enrollments")} · {totalSlots} {t("timeSlots")}{" "}
-          · {totalCapacity} {t("spots")}
+          {t("enrollmentsCount", { count: totalEnrollments })} ·{" "}
+          {t("timeSlotsCount", { count: totalSlots })} ·{" "}
+          {t("spotsCount", { count: totalCapacity })}
         </div>
       </div>
 
@@ -897,15 +898,37 @@ export default function PlanningPage({
 
                 {/* Unassigned solos */}
                 {unassignedSolos.map((enrollment) => {
-                  const hasPreferred = Object.values(
-                    enrollment.preferences
-                  ).some((p) => p === "Preferred" || p === "Available");
+                  const availableSlotIds = Object.entries(enrollment.preferences)
+                    .filter(([, p]) => p === "Preferred" || p === "Available")
+                    .map(([id]) => id);
+                  const hasPreferred = availableSlotIds.length > 0;
+                  const allAvailableAreFull = hasPreferred && availableSlotIds.every((slotId) => {
+                    const slot = planning.timeSlots.find((s) => s.id === slotId);
+                    if (!slot) return true;
+                    const count = (assignmentsBySlot.get(slot.id) ?? []).reduce((acc, a) => {
+                      if (a.enrollmentId) return acc + 1;
+                      if (a.groupId) {
+                        const g = groupMap.get(a.groupId);
+                        return acc + (g?.memberEnrollmentIds.length ?? 0);
+                      }
+                      return acc;
+                    }, 0);
+                    return count >= slot.maxCapacity;
+                  });
+                  const noSlotsConfigured = planning.timeSlots.length === 0;
+                  const reasonText = noSlotsConfigured
+                    ? t("noSlotsAvailable")
+                    : allAvailableAreFull
+                      ? t("noSlotCapacity")
+                      : hasPreferred
+                        ? t("multipleOptions")
+                        : t("noFittingSlot");
 
                   return (
                     <div
                       key={enrollment.id}
                       className={`border rounded-lg p-3 ${
-                        hasPreferred
+                        hasPreferred && !allAvailableAreFull
                           ? "border-amber-200 bg-amber-50/50"
                           : "border-red-200 bg-red-50/50"
                       }`}
@@ -913,7 +936,7 @@ export default function PlanningPage({
                       <div className="flex items-center gap-2 mb-2">
                         <div
                           className={`w-7 h-7 rounded-full flex items-center justify-center text-[10px] font-bold shrink-0 ${
-                            hasPreferred
+                            hasPreferred && !allAvailableAreFull
                               ? "bg-amber-100 text-amber-700"
                               : "bg-red-100 text-red-700"
                           }`}
@@ -926,14 +949,12 @@ export default function PlanningPage({
                           </div>
                           <div
                             className={`text-[10px] ${
-                              hasPreferred
+                              hasPreferred && !allAvailableAreFull
                                 ? "text-amber-600"
                                 : "text-red-600"
                             }`}
                           >
-                            {hasPreferred
-                              ? t("multipleOptions")
-                              : t("noFittingSlot")}
+                            {reasonText}
                           </div>
                         </div>
 

--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -147,7 +147,7 @@ export default function DashboardPage() {
   const statItems = [
     {
       value: String(summary?.lessonsTodayCount ?? 0),
-      label: t("statLessonsToday"),
+      label: t("statLessonsToday", { count: summary?.lessonsTodayCount ?? 0 }),
       color: "text-tennis-lime",
     },
     {
@@ -156,15 +156,15 @@ export default function DashboardPage() {
     },
     {
       value: `${summary?.totalEnrollmentCount ?? 0}`,
-      label: t("statEnrollments"),
+      label: t("statEnrollments", { count: summary?.totalEnrollmentCount ?? 0 }),
     },
     {
       value: String(summary?.activeTrainerCount ?? 0),
-      label: t("statTrainers"),
+      label: t("statTrainers", { count: summary?.activeTrainerCount ?? 0 }),
     },
     {
       value: String(summary?.activeSeriesCount ?? 0),
-      label: t("statSeries"),
+      label: t("statSeries", { count: summary?.activeSeriesCount ?? 0 }),
     },
   ];
 

--- a/frontend/app/(dashboard)/dashboard/trainers/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/trainers/page.tsx
@@ -24,6 +24,7 @@ import {
   TrainerDto,
 } from "@/lib/api/trainers";
 import { getAxiosErrorMessages } from "@/lib/utils/api-errors";
+import { getInitials } from "@/lib/utils/initials";
 import { getAuthUser, type AuthUser } from "@/lib/auth";
 import {
   AlertDialog,
@@ -435,7 +436,7 @@ export default function TrainersPage() {
       ) : (
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-3.5">
           {allTrainers.map((tr) => {
-            const initials = `${tr.firstName[0] ?? ""}${tr.lastName[0] ?? ""}`.toUpperCase();
+            const initials = getInitials(tr.firstName, tr.lastName);
             const isInvited = !tr.isActive && tr.invitePending;
             const isDeactivatedState = !tr.isActive && !tr.invitePending;
             // De eigen admin verschijnt alleen in deze lijst zolang AdminsActAsTrainers
@@ -548,13 +549,22 @@ export default function TrainersPage() {
                 {isInvited && (
                   <div className="mt-3 px-3 py-2.5 bg-amber-50/60 rounded-lg border border-dashed border-amber-200 flex justify-between items-center">
                     <p className="text-[11px] text-amber-800 m-0">{t("invitePending")}</p>
-                    <button
-                      onClick={() => resendMutation.mutate(tr.id)}
-                      disabled={resendMutation.isPending}
-                      className="px-2.5 py-1 bg-white border border-amber-300 rounded text-[10.5px] text-amber-800 font-semibold disabled:opacity-50"
-                    >
-                      {resendMutation.isPending ? t("resending") : t("resend")}
-                    </button>
+                    <div className="flex items-center gap-1.5">
+                      <button
+                        onClick={() => resendMutation.mutate(tr.id)}
+                        disabled={resendMutation.isPending}
+                        className="px-2.5 py-1 bg-white border border-amber-300 rounded text-[10.5px] text-amber-800 font-semibold disabled:opacity-50"
+                      >
+                        {resendMutation.isPending ? t("resending") : t("resend")}
+                      </button>
+                      <button
+                        onClick={() => handleRemoveClick(tr)}
+                        title={t("revokeInvite")}
+                        className="p-1.5 rounded text-amber-700 hover:text-red-500 hover:bg-red-50 transition-all"
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    </div>
                   </div>
                 )}
 

--- a/frontend/app/(public)/enroll/[seriesId]/page.tsx
+++ b/frontend/app/(public)/enroll/[seriesId]/page.tsx
@@ -470,7 +470,30 @@ export default function EnrollPage() {
             </div>
             <div className="flex items-center gap-2 text-sm text-gray-600">
               <Users className="w-4 h-4 text-gray-400 shrink-0" />
-              <span>{series.enrollmentCount} {t("enrolled").toLowerCase()}</span>
+              {series.maxRegistrations ? (
+                <span>
+                  {t("enrolledOfMax", {
+                    enrolled: series.enrollmentCount,
+                    max: series.maxRegistrations,
+                  })}
+                  {" — "}
+                  <span
+                    className={
+                      series.enrollmentCount >= series.maxRegistrations
+                        ? "text-red-600 font-medium"
+                        : series.enrollmentCount / series.maxRegistrations >= 0.8
+                          ? "text-amber-600 font-medium"
+                          : "text-tennis-green font-medium"
+                    }
+                  >
+                    {t("spotsLeft", {
+                      count: Math.max(0, series.maxRegistrations - series.enrollmentCount),
+                    })}
+                  </span>
+                </span>
+              ) : (
+                <span>{series.enrollmentCount} {t("enrolled").toLowerCase()}</span>
+              )}
             </div>
           </div>
         </div>

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -32,6 +32,7 @@ export default async function RootLayout({
     <html lang="nl">
       <body
         className={`${inter.variable} ${jetbrainsMono.variable} antialiased`}
+        suppressHydrationWarning
       >
         <NextIntlClientProvider messages={messages}>
           <QueryProvider>{children}</QueryProvider>

--- a/frontend/app/not-found.tsx
+++ b/frontend/app/not-found.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link";
+import { getTranslations } from "next-intl/server";
+
+export default async function NotFound() {
+  const t = await getTranslations("notFound");
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-[#FAFAF8] px-4">
+      <div className="max-w-md w-full text-center">
+        <div className="text-tennis-green text-7xl font-bold tracking-tight">
+          {t("subtitle")}
+        </div>
+        <h1 className="mt-4 text-2xl font-bold text-gray-900 tracking-tight">
+          {t("title")}
+        </h1>
+        <p className="mt-3 text-sm text-gray-500 leading-relaxed">
+          {t("description")}
+        </p>
+        <div className="mt-8 flex flex-col sm:flex-row gap-3 justify-center">
+          <Link
+            href="/dashboard"
+            className="inline-flex items-center justify-center px-5 py-2.5 bg-tennis-green text-white text-sm font-semibold rounded-lg hover:bg-tennis-green/90 transition-colors"
+          >
+            {t("backToDashboard")}
+          </Link>
+          <Link
+            href="/"
+            className="inline-flex items-center justify-center px-5 py-2.5 border border-gray-200 text-sm font-medium text-gray-700 rounded-lg hover:bg-white transition-colors"
+          >
+            {t("backToHome")}
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/layouts/dashboard-sidebar.tsx
+++ b/frontend/components/layouts/dashboard-sidebar.tsx
@@ -11,6 +11,7 @@ import { Mono } from "@/components/ui/mono";
 import { navItems } from "@/lib/nav-items";
 import { switchOrganization } from "@/lib/api/auth";
 import { getAuthUser, setAuthUser, setToken, clearAuth, type AuthUser } from "@/lib/auth";
+import { getInitials } from "@/lib/utils/initials";
 
 export function DashboardSidebar() {
   const pathname = usePathname();
@@ -71,7 +72,7 @@ export function DashboardSidebar() {
     ? `${user.firstName} ${user.lastName}`.trim() || "Coach"
     : "Coach";
   const initials = user
-    ? `${user.firstName?.[0] ?? ""}${user.lastName?.[0] ?? ""}`.toUpperCase() || "C"
+    ? getInitials(user.firstName, user.lastName)
     : "C";
 
   return (
@@ -87,12 +88,12 @@ export function DashboardSidebar() {
           </span>
         </div>
 
-        {/* Club switcher */}
+        {/* Organisation switcher */}
         {user?.memberships && user.memberships.length > 0 && (() => {
           const activeName =
             user.memberships.find((m) => m.organizationId === user.organizationId)
-              ?.organizationName ?? "Club";
-          const monogram = (activeName[0] ?? "C").toUpperCase();
+              ?.organizationName ?? tSwitcher("organizationFallback");
+          const monogram = getInitials(activeName) || "C";
           const canSwitch = user.memberships.length > 1;
 
           const tileClass =
@@ -106,7 +107,7 @@ export function DashboardSidebar() {
               </div>
               <div className="flex-1 min-w-0">
                 <p className="text-[10px] text-white/50 uppercase tracking-[0.08em] m-0">
-                  Club
+                  {tSwitcher("label")}
                 </p>
                 <p className="text-[11.5px] font-semibold text-white m-0 truncate">
                   {activeName}

--- a/frontend/lib/api/enrollments.ts
+++ b/frontend/lib/api/enrollments.ts
@@ -13,6 +13,7 @@ export interface PublicLessonSeriesDto {
   durationMinutes: number;
   tennisClubName: string;
   enrollmentCount: number;
+  maxRegistrations: number | null;
   lessons: LessonDto[];
 }
 

--- a/frontend/lib/utils/initials.ts
+++ b/frontend/lib/utils/initials.ts
@@ -1,0 +1,11 @@
+export function getInitial(name?: string | null): string {
+  if (!name) return "";
+  const match = name.match(/[A-Za-zÀ-ÖØ-öø-ÿ]/);
+  return match ? match[0].toUpperCase() : "";
+}
+
+export function getInitials(firstName?: string | null, lastName?: string | null): string {
+  const first = getInitial(firstName);
+  const last = getInitial(lastName);
+  return `${first}${last}` || "?";
+}

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -10,16 +10,25 @@
     "search": "Zoeken"
   },
   "orgSwitcher": {
-    "title": "Wissel van organisatie"
+    "title": "Wissel van organisatie",
+    "label": "Organisatie",
+    "organizationFallback": "Organisatie"
+  },
+  "notFound": {
+    "title": "Pagina niet gevonden",
+    "subtitle": "404",
+    "description": "We konden de pagina die je zocht niet vinden. Mogelijk is hij verplaatst of bestaat hij niet meer.",
+    "backToDashboard": "Terug naar dashboard",
+    "backToHome": "Terug naar home"
   },
   "dashboard": {
     "title": "Vandaag",
     "newLesson": "Nieuwe les",
-    "statLessonsToday": "lessen vandaag",
+    "statLessonsToday": "{count, plural, =0 {lessen vandaag} one {les vandaag} other {lessen vandaag}}",
     "statThisWeek": "deze week",
-    "statEnrollments": "inschrijvingen",
-    "statTrainers": "trainers",
-    "statSeries": "reeksen",
+    "statEnrollments": "{count, plural, =0 {inschrijvingen} one {inschrijving} other {inschrijvingen}}",
+    "statTrainers": "{count, plural, =0 {trainers} one {trainer} other {trainers}}",
+    "statSeries": "{count, plural, =0 {reeksen} one {reeks} other {reeksen}}",
     "priorityEmpty": "Alles onder controle",
     "priorityEmptyDesc": "Bevestigingen, betalingen en bezetting — alles is in orde.",
     "priorityLabel": "/vraagt-actie",
@@ -53,7 +62,7 @@
     "indoor": "Overdekt"
   },
   "lessonSeries": {
-    "title": "Lessen",
+    "title": "Lesreeksen",
     "subtitle": "Beheer je lesreeksen en lesmomenten",
     "create": "Nieuwe lesreeks",
     "empty": "Nog geen lesreeksen",
@@ -110,6 +119,8 @@
   "enrollments": {
     "title": "Inschrijvingen",
     "enrolled": "Ingeschreven",
+    "spotsLeft": "{count, plural, =0 {Volzet} one {Nog 1 plek vrij} other {Nog # plekken vrij}}",
+    "enrolledOfMax": "{enrolled} van {max} ingeschreven",
     "status_confirmed": "Bevestigd",
     "status_cancelled": "Geannuleerd",
     "enroll_success_title": "Ingeschreven!",
@@ -225,8 +236,13 @@
     "conflicts": "Conflicten",
     "enrollments": "inschrijvingen",
     "timeSlots": "tijdsloten",
+    "timeSlotsCount": "{count, plural, =0 {0 tijdsloten} one {1 tijdslot} other {# tijdsloten}}",
+    "enrollmentsCount": "{count, plural, =0 {0 inschrijvingen} one {1 inschrijving} other {# inschrijvingen}}",
+    "spotsCount": "{count, plural, =0 {0 plaatsen} one {1 plaats} other {# plaatsen}}",
     "spots": "plaatsen",
     "noFittingSlot": "Geen passend tijdslot",
+    "noSlotCapacity": "Geen plek meer in passende slots",
+    "noSlotsAvailable": "Geen tijdslot ingesteld",
     "multipleOptions": "Meerdere opties",
     "assignManually": "Handmatig toewijzen",
     "groups": "Groepen",
@@ -427,6 +443,7 @@
     "invitePending": "Uitnodiging verzonden",
     "deactivate": "Deactiveer",
     "remove": "Verwijder",
+    "revokeInvite": "Uitnodiging intrekken",
     "removeTitle": "Trainer verwijderen",
     "removeConfirm": "Weet je zeker dat je {name} wilt verwijderen? Dit kan niet ongedaan worden gemaakt.",
     "removeHasSeries": "{name} heeft {count} lesreeks(en). Wijs deze toe aan een andere trainer voor je verwijdert.",


### PR DESCRIPTION
## Summary
- **404 page** (`app/not-found.tsx`) with Dutch copy and back-to-dashboard CTA
- **Hydration warning** suppressed on `<body>` (browser extensions inject attributes)
- **Sidebar** label renamed from "Club" to "Organisatie" (via i18n) to match the dropdown
- **Avatar initials** strip non-alphabetic characters so `<script>` no longer renders as `<<`
- **Trainer invite** now has a "Uitnodiging intrekken" action next to "Opnieuw sturen"
- **Planning** unmatched-students message distinguishes 4 cases: no slots configured, capacity full, no matching availability, multiple options
- **Date format** consistent (`dd/MM/yyyy`) on lesson series detail
- **ICU pluralization** for `tijdsloten` / `inschrijvingen` / `trainers` / `reeksen`
- **Lesson series title** renamed to "Lesreeksen" to match sidebar
- **Lesson detail** week view opens on the first lesson's week, not empty week 1
- **Public enrollment** page shows "X van Y ingeschreven — Nog Z plekken vrij" with colour-coded urgency

## Why
Small UX wins flagged during exploratory QA — none change behaviour beyond what they show, but each removes confusion or visual noise.

## Test plan
- [ ] Navigate to `/lesreeksen` → localized 404 renders
- [ ] No hydration warning in console with ColorZilla / similar extension installed
- [ ] Sidebar shows "ORGANISATIE" label
- [ ] Dashboard shows "1 trainer" (not "1 trainers")
- [ ] Planning shows distinct reason text per unmatched student
- [ ] Lesson detail card shows `19/05/2026` not `2026-05-19`
- [ ] Public enrollment page shows remaining spots when MaxRegistrations is set

Refs #112 (Bugs #1, #2, #7, #8, #9, #14, L1-L8)