### PR TITLE
feat(infra): Mollie Connect secret placeholders

### DIFF
--- a/infrastructure/terraform/README.md
+++ b/infrastructure/terraform/README.md
@@ -79,3 +79,13 @@ setup (see `infrastructure/SECRETS.md`).
   manually (or extend this Terraform with `scaleway_iam_api_key` + tag)
 - Let's Encrypt SSL — handled inside the VPS by `bootstrap-vps.sh` via certbot
 - GitHub Actions secrets — set them in the GitHub UI per `SECRETS.md`
+- **Mollie Connect OAuth credentials** — after `tofu apply` lege secrets
+  `Mollie__ClientId` en `Mollie__ClientSecret` aanmaakt, vul je deze manueel in
+  na het aanmaken van het Mollie partner-account en het activeren van Mollie
+  Connect. Redirect URI in Mollie dashboard: `https://app.coach-os.be/api/oauth/mollie/callback`
+  (+ `http://localhost:5142/api/oauth/mollie/callback` voor dev).
+  Vul in via:
+  ```powershell
+  scw secret secret-version create <secret_id> data=<value>
+  ```
+  Of via de Scaleway console.

--- a/infrastructure/terraform/secrets.tf
+++ b/infrastructure/terraform/secrets.tf
@@ -42,6 +42,11 @@ locals {
     # Email__Username and Email__Password come from Scaleway TEM after domain
     # verification. Set them manually via `scw secret secret-version create`
     # or re-run `tofu apply` after filling in the `tem_smtp_*` variables.
+
+    # Mollie Connect — base URL where Mollie sends webhooks back to the API.
+    # The actual webhook path is /api/webhooks/mollie (handled by the API).
+    # ClientId and ClientSecret are manually filled (see resources below).
+    "Mollie__WebhookBaseUrl" = "https://app.${var.domain_name}"
   }
 }
 
@@ -75,4 +80,27 @@ resource "scaleway_secret" "super_admin_email" {
   name        = "SuperAdmin__Email"
   description = "E-mail van de eerste system-level super admin — manueel ingevuld"
   tags        = ["coach-os", "manual"]
+}
+
+# Mollie Connect OAuth credentials — manueel ingevuld na het aanmaken van het
+# Mollie partner-account en het activeren van Mollie Connect in het Mollie
+# dashboard. De redirect URI die in het Mollie dashboard moet worden ingesteld
+# is `https://app.<domain_name>/api/oauth/mollie/callback`.
+# Vul de waarden in via:
+#   scw secret secret-version create <secret_id> data=<value>
+# of via de Scaleway console.
+resource "scaleway_secret" "mollie_client_id" {
+  project_id  = var.scw_project_id
+  region      = var.scw_region
+  name        = "Mollie__ClientId"
+  description = "Mollie Connect OAuth client id — manueel ingevuld na Mollie onboarding"
+  tags        = ["coach-os", "manual", "mollie"]
+}
+
+resource "scaleway_secret" "mollie_client_secret" {
+  project_id  = var.scw_project_id
+  region      = var.scw_region
+  name        = "Mollie__ClientSecret"
+  description = "Mollie Connect OAuth client secret — manueel ingevuld na Mollie onboarding"
+  tags        = ["coach-os", "manual", "mollie"]
 }


### PR DESCRIPTION
## Summary

- Adds three Scaleway Secret Manager entries to prepare for Mollie OAuth integration
- `Mollie__WebhookBaseUrl` auto-filled from domain_name; `ClientId` and `ClientSecret` are empty placeholders
- Part 0 of multi-PR Mollie Connect onboarding flow — actual secrets filled manually post-Mollie-partner-account setup

## Test plan

- [ ] `tofu plan` shows 3 new resources (1 secret_version for WebhookBaseUrl, 2 empty secrets for ClientId/ClientSecret)
- [ ] `tofu apply` succeeds
- [ ] After apply, fill ClientId + ClientSecret manually via `scw secret secret-version create` once Mollie partner-account is set up
- [ ] Verify API container picks up `Mollie__WebhookBaseUrl` env var on next restart