### PR TITLE
feat(backend): mollie connect domain foundation

### DIFF
--- a/backend/CoachOS.Domain/Entities/LessonSerie.cs
+++ b/backend/CoachOS.Domain/Entities/LessonSerie.cs
@@ -24,6 +24,13 @@ public class LessonSerie : BaseEntity
     public int? MaxRegistrations { get; set; }
     public PlanningStatus PlanningStatus { get; set; } = PlanningStatus.Enrollment;
 
+    /// <summary>
+    /// Wanneer de leerling moet betalen voor deze reeks. <see cref="PaymentMode.Immediate"/>
+    /// stuurt direct door naar Mollie checkout; <see cref="PaymentMode.Deferred"/> verstuurt
+    /// een betaal-link per mail.
+    /// </summary>
+    public PaymentMode PaymentMode { get; set; } = PaymentMode.Immediate;
+
     public Guid TennisClubId { get; set; }
 
     // Navigation properties

--- a/backend/CoachOS.Domain/Entities/MollieConnection.cs
+++ b/backend/CoachOS.Domain/Entities/MollieConnection.cs
@@ -1,0 +1,35 @@
+using CoachOS.Domain.Common;
+
+namespace CoachOS.Domain.Entities;
+
+/// <summary>
+/// OAuth-koppeling tussen een CoachOS <see cref="Organization"/> en een Mollie-organisatie.
+/// 1-1 met <see cref="Organization"/>; bestaan van een rij = "verbonden".
+///
+/// Tokens zijn versleuteld at rest via <c>IDataProtectionProvider</c>; de plain values
+/// verlaten de Application-laag nooit en worden bij elk gebruik on-demand ontsleuteld.
+/// </summary>
+public class MollieConnection : BaseEntity
+{
+    public Guid OrganizationId { get; set; }
+
+    /// <summary>Identifier van de Mollie-organisatie (bv. <c>org_12345</c>).</summary>
+    public string MollieOrganizationId { get; set; } = string.Empty;
+
+    /// <summary>Versleutelde access token; ontsleutel via <c>ITokenProtector</c> voor gebruik.</summary>
+    public string AccessTokenEncrypted { get; set; } = string.Empty;
+
+    /// <summary>Versleutelde refresh token; ontsleutel via <c>ITokenProtector</c> voor gebruik.</summary>
+    public string RefreshTokenEncrypted { get; set; } = string.Empty;
+
+    /// <summary>UTC vervaltijd van de access token; gebruikt om proactief te refreshen.</summary>
+    public DateTime AccessTokenExpiresAt { get; set; }
+
+    /// <summary>Cached display-naam van de Mollie-organisatie voor UI ("Verbonden met ...").</summary>
+    public string? MollieOrganizationName { get; set; }
+
+    /// <summary>UTC moment waarop de koppeling initieel werd gemaakt.</summary>
+    public DateTime ConnectedAt { get; set; }
+
+    public Organization Organization { get; set; } = null!;
+}

--- a/backend/CoachOS.Domain/Entities/OAuthState.cs
+++ b/backend/CoachOS.Domain/Entities/OAuthState.cs
@@ -1,0 +1,22 @@
+using CoachOS.Domain.Common;
+
+namespace CoachOS.Domain.Entities;
+
+/// <summary>
+/// Eénmalige CSRF-state voor de Mollie OAuth-flow. Wordt aangemaakt bij
+/// "Connect to Mollie" (admin met JWT) en verbruikt door de anonieme callback
+/// endpoint om de bijhorende <see cref="OrganizationId"/> te herstellen.
+///
+/// Rijen worden verwijderd na succesvolle verbruik of na verloop van
+/// <see cref="ExpiresAt"/> via een achtergrond-cleanup taak.
+/// </summary>
+public class OAuthState : BaseEntity
+{
+    public Guid OrganizationId { get; set; }
+
+    /// <summary>Cryptografisch random state-token; unique.</summary>
+    public string State { get; set; } = string.Empty;
+
+    /// <summary>UTC moment waarop deze state ongeldig wordt (typisch +15 minuten).</summary>
+    public DateTime ExpiresAt { get; set; }
+}

--- a/backend/CoachOS.Domain/Entities/OrganizationSettings.cs
+++ b/backend/CoachOS.Domain/Entities/OrganizationSettings.cs
@@ -1,4 +1,5 @@
 using CoachOS.Domain.Common;
+using CoachOS.Domain.Enums;
 
 namespace CoachOS.Domain.Entities;
 
@@ -16,6 +17,21 @@ public class OrganizationSettings : BaseEntity
     /// admin-coach combinatie. Zet op false wanneer de admin puur administratief is.
     /// </summary>
     public bool AdminsActAsTrainers { get; set; } = true;
+
+    /// <summary>
+    /// Default <see cref="PaymentMode"/> die voorgeselecteerd wordt op nieuwe lesreeksen.
+    /// Admins kunnen per lesreeks afwijken.
+    /// </summary>
+    public PaymentMode DefaultPaymentMode { get; set; } = PaymentMode.Immediate;
+
+    /// <summary>
+    /// Platform-commissie als percentage (0–100, met 2 decimalen, bv. 2.50 = 2,5%).
+    /// Wordt enkel via super-admin gewijzigd; toegepast bij elke Mollie payment creation.
+    /// </summary>
+    public decimal PlatformFeePercentage { get; set; }
+
+    /// <summary>ISO 4217 currency code voor betalingen; default <c>EUR</c>.</summary>
+    public string PaymentCurrency { get; set; } = "EUR";
 
     public Organization Organization { get; set; } = null!;
 }

--- a/backend/CoachOS.Domain/Entities/Payment.cs
+++ b/backend/CoachOS.Domain/Entities/Payment.cs
@@ -21,6 +21,19 @@ public class Payment : BaseEntity
     public DateTime? PaidAt { get; set; }
     public string? Description { get; set; }
 
+    /// <summary>ISO 4217 currency code; default <c>EUR</c>. Kolom-default geldt voor seed/scripts.</summary>
+    public string Currency { get; set; } = "EUR";
+
+    /// <summary>
+    /// Snapshot van het platform-commissiebedrag (in EUR) op het moment van Mollie payment creation.
+    /// Bewaard zodat een latere wijziging van <c>OrganizationSettings.PlatformFeePercentage</c>
+    /// historische audits niet verstoort. <c>null</c> wanneer geen commissie is toegepast.
+    /// </summary>
+    public decimal? PlatformFee { get; set; }
+
+    /// <summary>Reden van mislukking zoals teruggegeven door Mollie (voor admin overview).</summary>
+    public string? FailureReason { get; set; }
+
     // Navigation properties
     public Organization Organization { get; set; } = null!;
     public Enrollment Enrollment { get; set; } = null!;

--- a/backend/CoachOS.Domain/Enums/EnrollmentStatus.cs
+++ b/backend/CoachOS.Domain/Enums/EnrollmentStatus.cs
@@ -5,5 +5,11 @@ public enum EnrollmentStatus
     Pending = 1,
     Confirmed = 2,
     Cancelled = 3,
-    Waitlisted = 4
+    Waitlisted = 4,
+
+    /// <summary>
+    /// Inschrijving is geregistreerd maar wacht op succesvolle Mollie-betaling.
+    /// Wordt <see cref="Confirmed"/> zodra de webhook een geslaagde betaling bevestigt.
+    /// </summary>
+    PendingPayment = 5
 }

--- a/backend/CoachOS.Domain/Enums/PaymentMode.cs
+++ b/backend/CoachOS.Domain/Enums/PaymentMode.cs
@@ -1,0 +1,13 @@
+namespace CoachOS.Domain.Enums;
+
+/// <summary>
+/// Bepaalt wanneer de leerling betaalt bij een inschrijving op een lesreeks.
+/// </summary>
+public enum PaymentMode
+{
+    /// <summary>Direct betalen via Mollie checkout op het moment van inschrijving.</summary>
+    Immediate = 0,
+
+    /// <summary>Betaal-link per mail ontvangen; inschrijving blijft <c>PendingPayment</c> tot betaling.</summary>
+    Deferred = 1
+}

--- a/backend/CoachOS.Domain/Interfaces/IMollieConnectionRepository.cs
+++ b/backend/CoachOS.Domain/Interfaces/IMollieConnectionRepository.cs
@@ -1,0 +1,18 @@
+using CoachOS.Domain.Entities;
+
+namespace CoachOS.Domain.Interfaces;
+
+public interface IMollieConnectionRepository
+{
+    /// <summary>Tracked read; gebruik voor mutaties (token refresh).</summary>
+    Task<MollieConnection?> GetByOrganizationAsync(Guid organizationId, CancellationToken ct = default);
+
+    /// <summary>AsNoTracking read; gebruik voor read-only checks zoals "is verbonden?".</summary>
+    Task<MollieConnection?> GetByOrganizationReadOnlyAsync(Guid organizationId, CancellationToken ct = default);
+
+    Task AddAsync(MollieConnection connection, CancellationToken ct = default);
+
+    Task DeleteByOrganizationAsync(Guid organizationId, CancellationToken ct = default);
+
+    Task SaveChangesAsync(CancellationToken ct = default);
+}

--- a/backend/CoachOS.Infrastructure/DependencyInjection.cs
+++ b/backend/CoachOS.Infrastructure/DependencyInjection.cs
@@ -79,6 +79,7 @@ public static class DependencyInjection
         services.AddScoped<IRescheduleRequestRepository, RescheduleRequestRepository>();
         services.AddScoped<ILessonInvitationRepository, LessonInvitationRepository>();
         services.AddScoped<IOrganizationSettingsRepository, OrganizationSettingsRepository>();
+        services.AddScoped<IMollieConnectionRepository, MollieConnectionRepository>();
 
         return services;
     }

--- a/backend/CoachOS.Infrastructure/Migrations/20260520172840_AddMolliePaymentSupport.Designer.cs
+++ b/backend/CoachOS.Infrastructure/Migrations/20260520172840_AddMolliePaymentSupport.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CoachOS.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CoachOS.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260520172840_AddMolliePaymentSupport")]
+    partial class AddMolliePaymentSupport
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/CoachOS.Infrastructure/Migrations/20260520172840_AddMolliePaymentSupport.cs
+++ b/backend/CoachOS.Infrastructure/Migrations/20260520172840_AddMolliePaymentSupport.cs
@@ -1,0 +1,186 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CoachOS.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMolliePaymentSupport : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Payments_MolliePaymentId",
+                table: "Payments");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Currency",
+                table: "Payments",
+                type: "character varying(3)",
+                maxLength: 3,
+                nullable: false,
+                defaultValue: "EUR");
+
+            migrationBuilder.AddColumn<string>(
+                name: "FailureReason",
+                table: "Payments",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "PlatformFee",
+                table: "Payments",
+                type: "numeric(10,2)",
+                precision: 10,
+                scale: 2,
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "DefaultPaymentMode",
+                table: "OrganizationSettings",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PaymentCurrency",
+                table: "OrganizationSettings",
+                type: "character varying(3)",
+                maxLength: 3,
+                nullable: false,
+                defaultValue: "EUR");
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "PlatformFeePercentage",
+                table: "OrganizationSettings",
+                type: "numeric(5,2)",
+                precision: 5,
+                scale: 2,
+                nullable: false,
+                defaultValue: 0m);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PaymentMode",
+                table: "LessonSeries",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateTable(
+                name: "MollieConnections",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    OrganizationId = table.Column<Guid>(type: "uuid", nullable: false),
+                    MollieOrganizationId = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    AccessTokenEncrypted = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: false),
+                    RefreshTokenEncrypted = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: false),
+                    AccessTokenExpiresAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    MollieOrganizationName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    ConnectedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MollieConnections", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_MollieConnections_Organizations_OrganizationId",
+                        column: x => x.OrganizationId,
+                        principalTable: "Organizations",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "OAuthStates",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    OrganizationId = table.Column<Guid>(type: "uuid", nullable: false),
+                    State = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    ExpiresAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OAuthStates", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Payments_MolliePaymentId",
+                table: "Payments",
+                column: "MolliePaymentId",
+                unique: true,
+                filter: "\"MolliePaymentId\" IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MollieConnections_OrganizationId",
+                table: "MollieConnections",
+                column: "OrganizationId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OAuthStates_ExpiresAt",
+                table: "OAuthStates",
+                column: "ExpiresAt");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OAuthStates_State",
+                table: "OAuthStates",
+                column: "State",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "MollieConnections");
+
+            migrationBuilder.DropTable(
+                name: "OAuthStates");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Payments_MolliePaymentId",
+                table: "Payments");
+
+            migrationBuilder.DropColumn(
+                name: "Currency",
+                table: "Payments");
+
+            migrationBuilder.DropColumn(
+                name: "FailureReason",
+                table: "Payments");
+
+            migrationBuilder.DropColumn(
+                name: "PlatformFee",
+                table: "Payments");
+
+            migrationBuilder.DropColumn(
+                name: "DefaultPaymentMode",
+                table: "OrganizationSettings");
+
+            migrationBuilder.DropColumn(
+                name: "PaymentCurrency",
+                table: "OrganizationSettings");
+
+            migrationBuilder.DropColumn(
+                name: "PlatformFeePercentage",
+                table: "OrganizationSettings");
+
+            migrationBuilder.DropColumn(
+                name: "PaymentMode",
+                table: "LessonSeries");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Payments_MolliePaymentId",
+                table: "Payments",
+                column: "MolliePaymentId");
+        }
+    }
+}

--- a/backend/CoachOS.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/backend/CoachOS.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -44,6 +44,8 @@ public class ApplicationDbContext(
     public DbSet<RescheduleRequest> RescheduleRequests { get; set; } = null!;
     public DbSet<LessonInvitation> LessonInvitations { get; set; } = null!;
     public DbSet<OrganizationSettings> OrganizationSettings { get; set; } = null!;
+    public DbSet<MollieConnection> MollieConnections { get; set; } = null!;
+    public DbSet<OAuthState> OAuthStates { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
@@ -69,6 +71,8 @@ public class ApplicationDbContext(
         builder.ApplyConfiguration(new RescheduleRequestConfiguration());
         builder.ApplyConfiguration(new LessonInvitationConfiguration());
         builder.ApplyConfiguration(new OrganizationSettingsConfiguration());
+        builder.ApplyConfiguration(new MollieConnectionConfiguration());
+        builder.ApplyConfiguration(new OAuthStateConfiguration());
 
         ApplyTenantFilters(builder);
     }
@@ -108,6 +112,10 @@ public class ApplicationDbContext(
         builder.Entity<LessonInvitation>().HasQueryFilter(e =>
             _tenant.OrganizationId == Guid.Empty || e.OrganizationId == _tenant.OrganizationId);
         builder.Entity<OrganizationSettings>().HasQueryFilter(e =>
+            _tenant.OrganizationId == Guid.Empty || e.OrganizationId == _tenant.OrganizationId);
+        builder.Entity<MollieConnection>().HasQueryFilter(e =>
+            _tenant.OrganizationId == Guid.Empty || e.OrganizationId == _tenant.OrganizationId);
+        builder.Entity<OAuthState>().HasQueryFilter(e =>
             _tenant.OrganizationId == Guid.Empty || e.OrganizationId == _tenant.OrganizationId);
     }
 

--- a/backend/CoachOS.Infrastructure/Persistence/Configurations/LessonSerieConfiguration.cs
+++ b/backend/CoachOS.Infrastructure/Persistence/Configurations/LessonSerieConfiguration.cs
@@ -20,6 +20,10 @@ public class LessonSerieConfiguration : IEntityTypeConfiguration<LessonSerie>
         builder.Property(ls => ls.Price)
             .HasPrecision(10, 2);
 
+        builder.Property(ls => ls.PaymentMode)
+            .IsRequired()
+            .HasDefaultValue(Domain.Enums.PaymentMode.Immediate);
+
         builder.HasOne(ls => ls.Organization)
             .WithMany(o => o.LessonSeries)
             .HasForeignKey(ls => ls.OrganizationId)

--- a/backend/CoachOS.Infrastructure/Persistence/Configurations/MollieConnectionConfiguration.cs
+++ b/backend/CoachOS.Infrastructure/Persistence/Configurations/MollieConnectionConfiguration.cs
@@ -1,0 +1,37 @@
+using CoachOS.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace CoachOS.Infrastructure.Persistence.Configurations;
+
+public class MollieConnectionConfiguration : IEntityTypeConfiguration<MollieConnection>
+{
+    public void Configure(EntityTypeBuilder<MollieConnection> builder)
+    {
+        builder.HasKey(c => c.Id);
+
+        builder.Property(c => c.MollieOrganizationId)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        // Token strings worden via DataProtection beschermd; ruime kolom om
+        // toekomstige rotaties / langere payloads op te vangen.
+        builder.Property(c => c.AccessTokenEncrypted)
+            .IsRequired()
+            .HasMaxLength(2000);
+
+        builder.Property(c => c.RefreshTokenEncrypted)
+            .IsRequired()
+            .HasMaxLength(2000);
+
+        builder.Property(c => c.MollieOrganizationName)
+            .HasMaxLength(200);
+
+        builder.HasOne(c => c.Organization)
+            .WithMany()
+            .HasForeignKey(c => c.OrganizationId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasIndex(c => c.OrganizationId).IsUnique();
+    }
+}

--- a/backend/CoachOS.Infrastructure/Persistence/Configurations/OAuthStateConfiguration.cs
+++ b/backend/CoachOS.Infrastructure/Persistence/Configurations/OAuthStateConfiguration.cs
@@ -1,0 +1,20 @@
+using CoachOS.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace CoachOS.Infrastructure.Persistence.Configurations;
+
+public class OAuthStateConfiguration : IEntityTypeConfiguration<OAuthState>
+{
+    public void Configure(EntityTypeBuilder<OAuthState> builder)
+    {
+        builder.HasKey(s => s.Id);
+
+        builder.Property(s => s.State)
+            .IsRequired()
+            .HasMaxLength(128);
+
+        builder.HasIndex(s => s.State).IsUnique();
+        builder.HasIndex(s => s.ExpiresAt);
+    }
+}

--- a/backend/CoachOS.Infrastructure/Persistence/Configurations/OrganizationSettingsConfiguration.cs
+++ b/backend/CoachOS.Infrastructure/Persistence/Configurations/OrganizationSettingsConfiguration.cs
@@ -14,6 +14,20 @@ public class OrganizationSettingsConfiguration : IEntityTypeConfiguration<Organi
             .IsRequired()
             .HasDefaultValue(true);
 
+        builder.Property(s => s.DefaultPaymentMode)
+            .IsRequired()
+            .HasDefaultValue(Domain.Enums.PaymentMode.Immediate);
+
+        builder.Property(s => s.PlatformFeePercentage)
+            .IsRequired()
+            .HasPrecision(5, 2)
+            .HasDefaultValue(0m);
+
+        builder.Property(s => s.PaymentCurrency)
+            .IsRequired()
+            .HasMaxLength(3)
+            .HasDefaultValue("EUR");
+
         builder.HasOne(s => s.Organization)
             .WithOne(o => o.Settings)
             .HasForeignKey<OrganizationSettings>(s => s.OrganizationId)

--- a/backend/CoachOS.Infrastructure/Persistence/Configurations/PaymentConfiguration.cs
+++ b/backend/CoachOS.Infrastructure/Persistence/Configurations/PaymentConfiguration.cs
@@ -26,6 +26,17 @@ public class PaymentConfiguration : IEntityTypeConfiguration<Payment>
         builder.Property(p => p.Description)
             .HasMaxLength(500);
 
+        builder.Property(p => p.Currency)
+            .IsRequired()
+            .HasMaxLength(3)
+            .HasDefaultValue("EUR");
+
+        builder.Property(p => p.PlatformFee)
+            .HasPrecision(10, 2);
+
+        builder.Property(p => p.FailureReason)
+            .HasMaxLength(500);
+
         builder.HasOne(p => p.Organization)
             .WithMany()
             .HasForeignKey(p => p.OrganizationId)
@@ -38,6 +49,10 @@ public class PaymentConfiguration : IEntityTypeConfiguration<Payment>
 
         builder.HasIndex(p => p.OrganizationId);
         builder.HasIndex(p => p.EnrollmentId);
-        builder.HasIndex(p => p.MolliePaymentId);
+
+        // Unique index voor webhook-lookup, alleen waar MolliePaymentId niet null is.
+        builder.HasIndex(p => p.MolliePaymentId)
+            .IsUnique()
+            .HasFilter("\"MolliePaymentId\" IS NOT NULL");
     }
 }

--- a/backend/CoachOS.Infrastructure/Repositories/MollieConnectionRepository.cs
+++ b/backend/CoachOS.Infrastructure/Repositories/MollieConnectionRepository.cs
@@ -1,0 +1,39 @@
+using CoachOS.Domain.Entities;
+using CoachOS.Domain.Interfaces;
+using CoachOS.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace CoachOS.Infrastructure.Repositories;
+
+public class MollieConnectionRepository(ApplicationDbContext context) : IMollieConnectionRepository
+{
+    public async Task<MollieConnection?> GetByOrganizationAsync(Guid organizationId, CancellationToken ct = default)
+    {
+        return await context.MollieConnections
+            .FirstOrDefaultAsync(c => c.OrganizationId == organizationId, ct);
+    }
+
+    public async Task<MollieConnection?> GetByOrganizationReadOnlyAsync(Guid organizationId, CancellationToken ct = default)
+    {
+        return await context.MollieConnections
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.OrganizationId == organizationId, ct);
+    }
+
+    public async Task AddAsync(MollieConnection connection, CancellationToken ct = default)
+    {
+        await context.MollieConnections.AddAsync(connection, ct);
+    }
+
+    public async Task DeleteByOrganizationAsync(Guid organizationId, CancellationToken ct = default)
+    {
+        await context.MollieConnections
+            .Where(c => c.OrganizationId == organizationId)
+            .ExecuteDeleteAsync(ct);
+    }
+
+    public async Task SaveChangesAsync(CancellationToken ct = default)
+    {
+        await context.SaveChangesAsync(ct);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `PaymentMode` enum (Immediate/Deferred) and `PaymentMode` field on `LessonSerie` to control enrollment payment timing
- Introduce `MollieConnection` entity (1:1 with Organization) to store encrypted OAuth tokens and Mollie merchant ID
- Add `OAuthState` entity for CSRF token protection during OAuth callback
- Extend `Payment` entity with `Currency`, `PlatformFee`, and `FailureReason` fields for audit integrity
- Extend `OrganizationSettings` with `DefaultPaymentMode`, `PlatformFeePercentage`, and `PaymentCurrency`
- Add `EnrollmentStatus.PendingPayment` enum value for payment-pending enrollments
- Create EF migration with safe defaults on new NOT NULL columns and unique partial index on `Payments.MolliePaymentId`
- Register `IMollieConnectionRepository` in DI container

## Why this design

Tokens live in a dedicated `MollieConnections` table (not on `Organization`) to isolate OAuth state and prevent accidental token leak via `SELECT * FROM Organizations`. Non-sensitive payment config lives in `OrganizationSettings` alongside `AdminsActAsTrainers`.

## Test plan

- [x] `dotnet build CoachOS.slnx` succeeds with 0 warnings, 0 errors
- [x] `dotnet test CoachOS.slnx --no-build` passes 172 tests, 0 failed
- [x] `bash backend/Scripts/reset-db.sh --no-frontend` wipes volume and applies migration on fresh startup
- [x] `bash backend/Scripts/seed-demo-data.sh` runs green end-to-end (admin, clubs, series, enrollments, planning, multi-org)
- [x] Migration includes safe defaults on new NOT NULL columns (no data backfill needed)
- [x] Unique partial index on `Payments.MolliePaymentId` prevents duplicate Mollie payment references

## Next

PR #2 will add the Mollie HTTP client wrapper, OAuth Connect service, and endpoints to initiate and complete the OAuth flow. Depends on this PR being merged.