### PR TITLE
feat(backend): mollie OAuth connect service + endpoints

### DIFF
--- a/backend/CoachOS.API/Endpoints/MollieConnect/CallbackEndpoint.cs
+++ b/backend/CoachOS.API/Endpoints/MollieConnect/CallbackEndpoint.cs
@@ -1,0 +1,48 @@
+using CoachOS.Application.Configuration;
+using CoachOS.Application.MollieConnect;
+using CoachOS.Domain.Models;
+using Microsoft.Extensions.Options;
+
+namespace CoachOS.API.Endpoints.MollieConnect;
+
+/// <summary>
+/// Mollie OAuth callback. Anoniem — Mollie roept dit aan in de browser van de
+/// admin. Server-side redirect naar de frontend settings-pagina met een
+/// query param zodat de UI een toast kan tonen.
+/// </summary>
+public class CallbackEndpoint : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/oauth/mollie/callback", async (
+            string? code,
+            string? state,
+            string? error,
+            IMollieConnectService service,
+            IOptions<AppOptions> appOptions,
+            HttpContext ctx,
+            CancellationToken ct) =>
+        {
+            string settingsUrl = $"{appOptions.Value.FrontendBaseUrl.TrimEnd('/')}/dashboard/settings";
+
+            // Mollie stuurt error= wanneer de gebruiker weigerde of er iets misging.
+            if (!string.IsNullOrEmpty(error))
+            {
+                return Results.Redirect($"{settingsUrl}?mollie=error");
+            }
+
+            if (string.IsNullOrEmpty(code) || string.IsNullOrEmpty(state))
+            {
+                return Results.Redirect($"{settingsUrl}?mollie=error");
+            }
+
+            string redirectUri = StartConnectEndpoint.BuildRedirectUri(ctx);
+            Result<Guid> result = await service.HandleCallbackAsync(code, state, redirectUri, ct);
+
+            string queryValue = result.IsSuccess ? "connected" : "error";
+            return Results.Redirect($"{settingsUrl}?mollie={queryValue}");
+        })
+        .AllowAnonymous()
+        .WithTags("MollieConnect");
+    }
+}

--- a/backend/CoachOS.API/Endpoints/MollieConnect/DisconnectEndpoint.cs
+++ b/backend/CoachOS.API/Endpoints/MollieConnect/DisconnectEndpoint.cs
@@ -1,0 +1,22 @@
+using CoachOS.API.Extensions;
+using CoachOS.Application.MollieConnect;
+using CoachOS.Domain.Models;
+
+namespace CoachOS.API.Endpoints.MollieConnect;
+
+public class DisconnectEndpoint : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPost("/mollie-connect/disconnect", async (
+            IMollieConnectService service,
+            HttpContext ctx,
+            CancellationToken ct) =>
+        {
+            Result result = await service.DisconnectAsync(ctx.GetOrganizationId(), ct);
+            return result.IsSuccess ? Results.NoContent() : result.ToErrorResult();
+        })
+        .RequireAuthorization(policy => policy.RequireRole("Admin"))
+        .WithTags("MollieConnect");
+    }
+}

--- a/backend/CoachOS.API/Endpoints/MollieConnect/GetStatusEndpoint.cs
+++ b/backend/CoachOS.API/Endpoints/MollieConnect/GetStatusEndpoint.cs
@@ -1,0 +1,24 @@
+using CoachOS.API.Extensions;
+using CoachOS.Application.MollieConnect;
+using CoachOS.Application.MollieConnect.DTOs;
+using CoachOS.Domain.Models;
+
+namespace CoachOS.API.Endpoints.MollieConnect;
+
+public class GetStatusEndpoint : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/mollie-connect/status", async (
+            IMollieConnectService service,
+            HttpContext ctx,
+            CancellationToken ct) =>
+        {
+            Result<MollieConnectionStatusDto> result = await service.GetStatusAsync(
+                ctx.GetOrganizationId(), ct);
+            return result.IsSuccess ? Results.Ok(result.Value) : result.ToErrorResult();
+        })
+        .RequireAuthorization(policy => policy.RequireRole("Admin"))
+        .WithTags("MollieConnect");
+    }
+}

--- a/backend/CoachOS.API/Endpoints/MollieConnect/StartConnectEndpoint.cs
+++ b/backend/CoachOS.API/Endpoints/MollieConnect/StartConnectEndpoint.cs
@@ -1,0 +1,39 @@
+using CoachOS.API.Extensions;
+using CoachOS.Application.MollieConnect;
+using CoachOS.Application.MollieConnect.DTOs;
+using CoachOS.Domain.Models;
+
+namespace CoachOS.API.Endpoints.MollieConnect;
+
+/// <summary>
+/// Genereert de Mollie OAuth-autorisatie-URL voor de huidige organisatie.
+/// Frontend roept dit aan en doet vervolgens <c>window.location.href = AuthorizationUrl</c>.
+/// </summary>
+public class StartConnectEndpoint : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPost("/mollie-connect/start", async (
+            IMollieConnectService service,
+            HttpContext ctx,
+            CancellationToken ct) =>
+        {
+            string redirectUri = BuildRedirectUri(ctx);
+            Result<StartConnectResponse> result = await service.StartAsync(
+                ctx.GetOrganizationId(), redirectUri, ct);
+            return result.IsSuccess ? Results.Ok(result.Value) : result.ToErrorResult();
+        })
+        .RequireAuthorization(policy => policy.RequireRole("Admin"))
+        .WithTags("MollieConnect");
+    }
+
+    /// <summary>
+    /// Bouwt de redirect URI consistent op basis van de inkomende request, zodat
+    /// dev (localhost) en prod (app.coach-os.be) hetzelfde codepad delen. De URL
+    /// moet exact matchen met wat in het Mollie dashboard is geregistreerd.
+    /// </summary>
+    internal static string BuildRedirectUri(HttpContext ctx)
+    {
+        return $"{ctx.Request.Scheme}://{ctx.Request.Host}/api/oauth/mollie/callback";
+    }
+}

--- a/backend/CoachOS.API/Extensions/ResultExtensions.cs
+++ b/backend/CoachOS.API/Extensions/ResultExtensions.cs
@@ -31,6 +31,7 @@ public static class ResultExtensions
             ErrorCodes.Forbidden => StatusCodes.Status403Forbidden,
             ErrorCodes.Conflict => StatusCodes.Status409Conflict,
             ErrorCodes.Unexpected => StatusCodes.Status500InternalServerError,
+            ErrorCodes.ExternalService => StatusCodes.Status502BadGateway,
             _ => StatusCodes.Status400BadRequest,
         };
     }

--- a/backend/CoachOS.Application/Configuration/MollieOptions.cs
+++ b/backend/CoachOS.Application/Configuration/MollieOptions.cs
@@ -1,0 +1,47 @@
+namespace CoachOS.Application.Configuration;
+
+/// <summary>
+/// Configuratie voor de Mollie Connect integratie. Bind aan de
+/// <c>Mollie:</c> sectie. Productie-secrets komen uit Scaleway Secret
+/// Manager (<c>Mollie__ClientId</c>, <c>Mollie__ClientSecret</c>,
+/// <c>Mollie__WebhookBaseUrl</c>). Lokaal dev kan via
+/// <c>appsettings.Development.json</c>.
+/// </summary>
+public class MollieOptions
+{
+    public const string Section = "Mollie";
+
+    /// <summary>Mollie Connect OAuth client id.</summary>
+    public string ClientId { get; set; } = string.Empty;
+
+    /// <summary>Mollie Connect OAuth client secret.</summary>
+    public string ClientSecret { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Publieke base URL waarop Mollie webhooks aflevert (bv. <c>https://app.coach-os.be</c>).
+    /// De effectieve webhook endpoint is <c>{WebhookBaseUrl}/api/webhooks/mollie</c>.
+    /// Wordt door <c>PaymentService</c> in PR #4 gebruikt; nu al gebonden zodat de
+    /// config-validatie in DI eenduidig blijft.
+    /// </summary>
+    public string WebhookBaseUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Volledige redirect URI die in het Mollie dashboard is geregistreerd.
+    /// Moet exact matchen met wat in OAuth flow wordt meegestuurd, inclusief
+    /// scheme en pad. Default: leeg → wordt op runtime afgeleid van de inkomende
+    /// request (<c>{scheme}://{host}/api/oauth/mollie/callback</c>).
+    /// </summary>
+    public string RedirectUri { get; set; } = string.Empty;
+
+    /// <summary>Mollie API base URL (overschrijfbaar voor tests). Default: <c>https://api.mollie.com</c>.</summary>
+    public string ApiBaseUrl { get; set; } = "https://api.mollie.com";
+
+    /// <summary>Mollie OAuth dialog base URL (overschrijfbaar voor tests). Default: <c>https://my.mollie.com</c>.</summary>
+    public string OAuthBaseUrl { get; set; } = "https://my.mollie.com";
+
+    /// <summary>
+    /// Komma-gescheiden lijst van scopes die in de OAuth-autorisatie-URL worden gevraagd.
+    /// Defaults dekken alles wat CoachOS nodig heeft voor onboarding + payments.
+    /// </summary>
+    public string Scopes { get; set; } = "payments.read payments.write organizations.read profiles.read profiles.write onboarding.read";
+}

--- a/backend/CoachOS.Application/MollieConnect/DTOs/MollieConnectionStatusDto.cs
+++ b/backend/CoachOS.Application/MollieConnect/DTOs/MollieConnectionStatusDto.cs
@@ -1,0 +1,11 @@
+namespace CoachOS.Application.MollieConnect.DTOs;
+
+/// <summary>
+/// Status van de Mollie-koppeling voor een organisatie. Door de admin-UI getoond
+/// in de settings-pagina. <see cref="MollieOrganizationName"/> is enkel gezet
+/// wanneer <see cref="Connected"/> true is.
+/// </summary>
+public record MollieConnectionStatusDto(
+    bool Connected,
+    string? MollieOrganizationName,
+    DateTime? ConnectedAt);

--- a/backend/CoachOS.Application/MollieConnect/DTOs/StartConnectResponse.cs
+++ b/backend/CoachOS.Application/MollieConnect/DTOs/StartConnectResponse.cs
@@ -1,0 +1,7 @@
+namespace CoachOS.Application.MollieConnect.DTOs;
+
+/// <summary>
+/// Response van <c>POST /api/mollie-connect/start</c>. Frontend doet vervolgens
+/// <c>window.location.href = AuthorizationUrl</c>.
+/// </summary>
+public record StartConnectResponse(string AuthorizationUrl);

--- a/backend/CoachOS.Application/MollieConnect/IMollieConnectService.cs
+++ b/backend/CoachOS.Application/MollieConnect/IMollieConnectService.cs
@@ -1,0 +1,34 @@
+using CoachOS.Application.MollieConnect.DTOs;
+using CoachOS.Domain.Models;
+
+namespace CoachOS.Application.MollieConnect;
+
+public interface IMollieConnectService
+{
+    /// <summary>
+    /// Genereert een CSRF state-token en bouwt de Mollie OAuth-autorisatie-URL.
+    /// De frontend redirect de gebruiker naar deze URL.
+    /// </summary>
+    Task<Result<StartConnectResponse>> StartAsync(
+        Guid organizationId,
+        string redirectUri,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Handelt de OAuth-callback af: valideert state, wisselt code in voor tokens,
+    /// haalt Mollie organisatie-info op en bewaart de versleutelde tokens als
+    /// <c>MollieConnection</c>. Retourneert de gerelateerde <see cref="Guid"/>
+    /// organizationId zodat de endpoint een correcte redirect-URL kan bouwen.
+    /// </summary>
+    Task<Result<Guid>> HandleCallbackAsync(
+        string code,
+        string state,
+        string redirectUri,
+        CancellationToken ct = default);
+
+    /// <summary>Trekt de Mollie tokens in en verwijdert de <c>MollieConnection</c>.</summary>
+    Task<Result> DisconnectAsync(Guid organizationId, CancellationToken ct = default);
+
+    /// <summary>Read-only status-check; gebruikt door de admin settings-pagina.</summary>
+    Task<Result<MollieConnectionStatusDto>> GetStatusAsync(Guid organizationId, CancellationToken ct = default);
+}

--- a/backend/CoachOS.Application/MollieConnect/MollieConnectService.cs
+++ b/backend/CoachOS.Application/MollieConnect/MollieConnectService.cs
@@ -1,0 +1,203 @@
+using System.Security.Cryptography;
+using System.Web;
+using CoachOS.Application.Configuration;
+using CoachOS.Application.MollieConnect.DTOs;
+using CoachOS.Domain.Entities;
+using CoachOS.Domain.Interfaces;
+using CoachOS.Domain.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace CoachOS.Application.MollieConnect;
+
+public class MollieConnectService(
+    IMollieClient mollieClient,
+    IMollieConnectionRepository connections,
+    IOAuthStateRepository states,
+    ITokenProtector protector,
+    IOptions<MollieOptions> options,
+    TimeProvider timeProvider,
+    ILogger<MollieConnectService> logger) : IMollieConnectService
+{
+    private const int StateTtlMinutes = 15;
+    private const int StateByteLength = 32;
+
+    private readonly MollieOptions _options = options.Value;
+
+    public async Task<Result<StartConnectResponse>> StartAsync(
+        Guid organizationId,
+        string redirectUri,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(_options.ClientId))
+        {
+            logger.LogError("Mollie ClientId is niet geconfigureerd; OAuth start onmogelijk.");
+            return Result<StartConnectResponse>.Fail(new Error(
+                ErrorCodes.ExternalService,
+                "Mollie-integratie is niet geconfigureerd op deze omgeving."));
+        }
+
+        string state = GenerateSecureToken();
+        DateTime utcNow = timeProvider.GetUtcNow().UtcDateTime;
+
+        OAuthState entity = new()
+        {
+            OrganizationId = organizationId,
+            State = state,
+            ExpiresAt = utcNow.AddMinutes(StateTtlMinutes),
+        };
+        await states.AddAsync(entity, ct);
+        await states.SaveChangesAsync(ct);
+
+        string url = BuildAuthorizationUrl(state, redirectUri);
+        return Result<StartConnectResponse>.Ok(new StartConnectResponse(url));
+    }
+
+    public async Task<Result<Guid>> HandleCallbackAsync(
+        string code,
+        string state,
+        string redirectUri,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(code) || string.IsNullOrWhiteSpace(state))
+        {
+            return Result<Guid>.Fail(new Error(
+                ErrorCodes.Validation,
+                "Onvolledige OAuth-callback van Mollie."));
+        }
+
+        OAuthState? stored = await states.GetByStateAsync(state, ct);
+        if (stored is null)
+        {
+            logger.LogWarning("OAuth callback met onbekende state ontvangen.");
+            return Result<Guid>.Fail(new Error(
+                ErrorCodes.Unauthorized,
+                "Ongeldige of verlopen OAuth-state."));
+        }
+
+        DateTime utcNow = timeProvider.GetUtcNow().UtcDateTime;
+        if (stored.ExpiresAt < utcNow)
+        {
+            await states.DeleteAsync(stored, ct);
+            await states.SaveChangesAsync(ct);
+            return Result<Guid>.Fail(new Error(
+                ErrorCodes.Unauthorized,
+                "Deze koppelingspoging is verlopen, probeer opnieuw."));
+        }
+
+        Result<MollieTokenResponse> tokenResult = await mollieClient.ExchangeCodeForTokenAsync(code, redirectUri, ct);
+        if (!tokenResult.IsSuccess)
+        {
+            // State opbruiken zodat dezelfde code niet opnieuw kan worden geprobeerd.
+            await states.DeleteAsync(stored, ct);
+            await states.SaveChangesAsync(ct);
+            return Result<Guid>.Fail(tokenResult.Errors);
+        }
+
+        MollieTokenResponse tokens = tokenResult.Value!;
+        Result<MollieOrganizationInfo> orgResult = await mollieClient.GetOrganizationAsync(tokens.AccessToken, ct);
+        if (!orgResult.IsSuccess)
+        {
+            await states.DeleteAsync(stored, ct);
+            await states.SaveChangesAsync(ct);
+            return Result<Guid>.Fail(orgResult.Errors);
+        }
+
+        // Upsert: verwijder eventuele oude connectie (her-connect na disconnect),
+        // dan nieuwe rij. Goedkoper dan in-place update + dekt tabel-state altijd.
+        await connections.DeleteByOrganizationAsync(stored.OrganizationId, ct);
+
+        MollieConnection connection = new()
+        {
+            OrganizationId = stored.OrganizationId,
+            MollieOrganizationId = orgResult.Value!.Id,
+            MollieOrganizationName = orgResult.Value!.Name,
+            AccessTokenEncrypted = protector.Protect(tokens.AccessToken),
+            RefreshTokenEncrypted = protector.Protect(tokens.RefreshToken),
+            AccessTokenExpiresAt = utcNow.AddSeconds(tokens.ExpiresInSeconds),
+            ConnectedAt = utcNow,
+        };
+        await connections.AddAsync(connection, ct);
+        await connections.SaveChangesAsync(ct);
+
+        await states.DeleteAsync(stored, ct);
+        await states.SaveChangesAsync(ct);
+
+        return Result<Guid>.Ok(stored.OrganizationId);
+    }
+
+    public async Task<Result> DisconnectAsync(Guid organizationId, CancellationToken ct = default)
+    {
+        MollieConnection? existing = await connections.GetByOrganizationAsync(organizationId, ct);
+        if (existing is null)
+        {
+            // Niet verbonden = niets te doen; idempotent.
+            return Result.Ok();
+        }
+
+        // Probeer Mollie token in te trekken; we negeren netwerkfouten zodat de
+        // lokale state altijd consistent eindigt (geen "deels verbonden").
+        try
+        {
+            string refreshToken = protector.Unprotect(existing.RefreshTokenEncrypted);
+            Result revokeResult = await mollieClient.RevokeRefreshTokenAsync(refreshToken, ct);
+            if (!revokeResult.IsSuccess)
+            {
+                logger.LogWarning("Mollie token revoke faalde voor org {OrgId}; lokale connectie wordt alsnog verwijderd.", organizationId);
+            }
+        }
+        catch (CryptographicException ex)
+        {
+            logger.LogError(ex, "Refresh token voor org {OrgId} kon niet worden ontsleuteld; verwijder enkel lokaal.", organizationId);
+        }
+
+        await connections.DeleteByOrganizationAsync(organizationId, ct);
+        await connections.SaveChangesAsync(ct);
+        return Result.Ok();
+    }
+
+    public async Task<Result<MollieConnectionStatusDto>> GetStatusAsync(
+        Guid organizationId,
+        CancellationToken ct = default)
+    {
+        MollieConnection? connection = await connections.GetByOrganizationReadOnlyAsync(organizationId, ct);
+        if (connection is null)
+        {
+            return Result<MollieConnectionStatusDto>.Ok(new MollieConnectionStatusDto(false, null, null));
+        }
+
+        return Result<MollieConnectionStatusDto>.Ok(new MollieConnectionStatusDto(
+            true,
+            connection.MollieOrganizationName,
+            connection.ConnectedAt));
+    }
+
+    private string BuildAuthorizationUrl(string state, string redirectUri)
+    {
+        // Mollie verwacht space-separated scopes in de scope query param.
+        // We laten de URL-encoder dit voor zijn rekening nemen.
+        Dictionary<string, string> queryParams = new()
+        {
+            ["client_id"] = _options.ClientId,
+            ["redirect_uri"] = redirectUri,
+            ["state"] = state,
+            ["scope"] = _options.Scopes,
+            ["response_type"] = "code",
+            ["approval_prompt"] = "auto",
+        };
+        string query = string.Join("&", queryParams
+            .Select(kv => $"{HttpUtility.UrlEncode(kv.Key)}={HttpUtility.UrlEncode(kv.Value)}"));
+        return $"{_options.OAuthBaseUrl}/oauth2/authorize?{query}";
+    }
+
+    private static string GenerateSecureToken()
+    {
+        byte[] bytes = RandomNumberGenerator.GetBytes(StateByteLength);
+        // Url-safe base64: vervang +/= door -_ (zonder padding) zodat de string
+        // veilig in een query parameter past zonder extra encoding-noise.
+        return Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+}

--- a/backend/CoachOS.Domain/Interfaces/IMollieClient.cs
+++ b/backend/CoachOS.Domain/Interfaces/IMollieClient.cs
@@ -1,0 +1,45 @@
+using CoachOS.Domain.Models;
+
+namespace CoachOS.Domain.Interfaces;
+
+/// <summary>
+/// Mollie REST API wrapper. Hier zijn enkel de calls nodig voor OAuth onboarding
+/// (PR #2). Payment-gerelateerde calls (<c>CreatePaymentAsync</c>,
+/// <c>GetPaymentAsync</c>) komen in PR #4.
+/// </summary>
+public interface IMollieClient
+{
+    /// <summary>Wisselt een authorization <paramref name="code"/> in voor access + refresh tokens.</summary>
+    Task<Result<MollieTokenResponse>> ExchangeCodeForTokenAsync(
+        string code,
+        string redirectUri,
+        CancellationToken ct = default);
+
+    /// <summary>Vernieuwt een access token met een refresh token.</summary>
+    Task<Result<MollieTokenResponse>> RefreshTokenAsync(
+        string refreshToken,
+        CancellationToken ct = default);
+
+    /// <summary>Haalt de Mollie-organisatie op voor het gegeven access token (<c>GET /v2/organizations/me</c>).</summary>
+    Task<Result<MollieOrganizationInfo>> GetOrganizationAsync(
+        string accessToken,
+        CancellationToken ct = default);
+
+    /// <summary>Trekt een refresh token (en de bijbehorende access tokens) in.</summary>
+    Task<Result> RevokeRefreshTokenAsync(
+        string refreshToken,
+        CancellationToken ct = default);
+}
+
+/// <summary>Antwoord van Mollie's <c>POST /oauth2/tokens</c>.</summary>
+public sealed record MollieTokenResponse(
+    string AccessToken,
+    string RefreshToken,
+    int ExpiresInSeconds,
+    string TokenType,
+    string Scope);
+
+/// <summary>Subset van <c>GET /v2/organizations/me</c> die we cachen.</summary>
+public sealed record MollieOrganizationInfo(
+    string Id,
+    string Name);

--- a/backend/CoachOS.Domain/Interfaces/IOAuthStateRepository.cs
+++ b/backend/CoachOS.Domain/Interfaces/IOAuthStateRepository.cs
@@ -1,0 +1,18 @@
+using CoachOS.Domain.Entities;
+
+namespace CoachOS.Domain.Interfaces;
+
+public interface IOAuthStateRepository
+{
+    Task AddAsync(OAuthState state, CancellationToken ct = default);
+
+    /// <summary>Haalt een state op via de random token (tracked, want consumeren = delete).</summary>
+    Task<OAuthState?> GetByStateAsync(string state, CancellationToken ct = default);
+
+    Task DeleteAsync(OAuthState state, CancellationToken ct = default);
+
+    /// <summary>Bulk-cleanup van verlopen rijen; geroepen door een hosted service of admin tool.</summary>
+    Task<int> DeleteExpiredAsync(DateTime utcNow, CancellationToken ct = default);
+
+    Task SaveChangesAsync(CancellationToken ct = default);
+}

--- a/backend/CoachOS.Domain/Interfaces/ITokenProtector.cs
+++ b/backend/CoachOS.Domain/Interfaces/ITokenProtector.cs
@@ -1,0 +1,18 @@
+namespace CoachOS.Domain.Interfaces;
+
+/// <summary>
+/// At-rest encryption van gevoelige strings (Mollie OAuth tokens). Implementatie
+/// gebruikt ASP.NET Core <c>IDataProtectionProvider</c>. De plaintext verlaat
+/// nooit de Application-laag.
+/// </summary>
+public interface ITokenProtector
+{
+    string Protect(string plaintext);
+
+    /// <summary>
+    /// Ontsleutelt de payload. Werpt <see cref="System.Security.Cryptography.CryptographicException"/>
+    /// wanneer de payload corrupt is of versleuteld werd met een sleutel die niet
+    /// meer beschikbaar is (bv. keystore-verlies).
+    /// </summary>
+    string Unprotect(string protectedData);
+}

--- a/backend/CoachOS.Domain/Models/ErrorCodes.cs
+++ b/backend/CoachOS.Domain/Models/ErrorCodes.cs
@@ -8,4 +8,10 @@ public static class ErrorCodes
     public const string Forbidden = "forbidden";
     public const string Conflict = "conflict";
     public const string Unexpected = "unexpected";
+
+    /// <summary>
+    /// Externe afhankelijkheid (third-party API) faalde of antwoordde onverwacht.
+    /// Mappet op HTTP 502 Bad Gateway in <c>ResultExtensions</c>.
+    /// </summary>
+    public const string ExternalService = "external_service";
 }

--- a/backend/CoachOS.Infrastructure/DependencyInjection.cs
+++ b/backend/CoachOS.Infrastructure/DependencyInjection.cs
@@ -1,14 +1,18 @@
 using CoachOS.Application.Auth;
 using CoachOS.Application.Configuration;
+using CoachOS.Application.MollieConnect;
 using CoachOS.Application.StudentAuth;
 using CoachOS.Application.SuperAdmin;
 using CoachOS.Application.Trainers;
 using CoachOS.Domain.Interfaces;
 using CoachOS.Infrastructure.Email;
 using CoachOS.Infrastructure.Identity;
+using CoachOS.Infrastructure.Mollie;
 using CoachOS.Infrastructure.MultiTenancy;
 using CoachOS.Infrastructure.Persistence;
 using CoachOS.Infrastructure.Repositories;
+using CoachOS.Infrastructure.Security;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -52,6 +56,26 @@ public static class DependencyInjection
 
         services.Configure<EmailOptions>(configuration.GetSection(EmailOptions.Section));
         services.Configure<AppOptions>(configuration.GetSection(AppOptions.Section));
+        services.Configure<MollieOptions>(configuration.GetSection(MollieOptions.Section));
+
+        // TimeProvider is in .NET 8+ ingebouwd; testen kunnen FakeTimeProvider injecteren.
+        services.AddSingleton(TimeProvider.System);
+
+        // DataProtection sleutels persisteren naar disk zodat container-restarts
+        // bestaande versleutelde Mollie tokens niet onleesbaar maken. Path is
+        // configureerbaar via DataProtection:KeyDirectory; default is een vaste
+        // map die in productie via een persistent volume gemount moet worden.
+        string keyDirectory = configuration["DataProtection:KeyDirectory"]
+                              ?? configuration["DataProtection__KeyDirectory"]
+                              ?? Path.Combine(Path.GetTempPath(), "coachos-data-protection-keys");
+        Directory.CreateDirectory(keyDirectory);
+        services.AddDataProtection()
+            .SetApplicationName("CoachOS")
+            .PersistKeysToFileSystem(new DirectoryInfo(keyDirectory));
+
+        services.AddHttpClient<IMollieClient, MollieClient>();
+        services.AddScoped<ITokenProtector, DataProtectionTokenProtector>();
+        services.AddScoped<IMollieConnectService, MollieConnectService>();
 
         services.AddScoped<TenantContext>();
         services.AddScoped<ITenantContext>(sp => sp.GetRequiredService<TenantContext>());
@@ -80,6 +104,7 @@ public static class DependencyInjection
         services.AddScoped<ILessonInvitationRepository, LessonInvitationRepository>();
         services.AddScoped<IOrganizationSettingsRepository, OrganizationSettingsRepository>();
         services.AddScoped<IMollieConnectionRepository, MollieConnectionRepository>();
+        services.AddScoped<IOAuthStateRepository, OAuthStateRepository>();
 
         return services;
     }

--- a/backend/CoachOS.Infrastructure/Mollie/MollieClient.cs
+++ b/backend/CoachOS.Infrastructure/Mollie/MollieClient.cs
@@ -1,0 +1,192 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using CoachOS.Application.Configuration;
+using CoachOS.Domain.Interfaces;
+using CoachOS.Domain.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace CoachOS.Infrastructure.Mollie;
+
+/// <summary>
+/// Mollie REST API client. Endpoint paths volgen Mollie's officiële documentatie:
+/// <c>POST /oauth2/tokens</c>, <c>DELETE /oauth2/tokens</c>, <c>GET /v2/organizations/me</c>.
+/// Auth voor de OAuth token endpoint is HTTP Basic (client_id:client_secret); voor
+/// resource endpoints is het een Bearer access token.
+/// </summary>
+public class MollieClient(
+    HttpClient httpClient,
+    IOptions<MollieOptions> options,
+    ILogger<MollieClient> logger) : IMollieClient
+{
+    private readonly MollieOptions _options = options.Value;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    public async Task<Result<MollieTokenResponse>> ExchangeCodeForTokenAsync(
+        string code,
+        string redirectUri,
+        CancellationToken ct = default)
+    {
+        IReadOnlyDictionary<string, string> form = new Dictionary<string, string>
+        {
+            ["grant_type"] = "authorization_code",
+            ["code"] = code,
+            ["redirect_uri"] = redirectUri,
+        };
+        return await PostTokenAsync(form, ct);
+    }
+
+    public async Task<Result<MollieTokenResponse>> RefreshTokenAsync(
+        string refreshToken,
+        CancellationToken ct = default)
+    {
+        IReadOnlyDictionary<string, string> form = new Dictionary<string, string>
+        {
+            ["grant_type"] = "refresh_token",
+            ["refresh_token"] = refreshToken,
+        };
+        return await PostTokenAsync(form, ct);
+    }
+
+    public async Task<Result<MollieOrganizationInfo>> GetOrganizationAsync(
+        string accessToken,
+        CancellationToken ct = default)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Get, $"{_options.ApiBaseUrl}/v2/organizations/me");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+        try
+        {
+            using HttpResponseMessage response = await httpClient.SendAsync(request, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                string body = await response.Content.ReadAsStringAsync(ct);
+                logger.LogWarning("Mollie /organizations/me gaf {Status}: {Body}", (int)response.StatusCode, body);
+                return Result<MollieOrganizationInfo>.Fail(new Error(
+                    ErrorCodes.ExternalService,
+                    "Kon Mollie organisatie-info niet ophalen."));
+            }
+
+            MollieOrganizationPayload? payload = await response.Content.ReadFromJsonAsync<MollieOrganizationPayload>(JsonOptions, ct);
+            if (payload is null || string.IsNullOrEmpty(payload.Id))
+            {
+                return Result<MollieOrganizationInfo>.Fail(new Error(
+                    ErrorCodes.ExternalService,
+                    "Mollie gaf een leeg organisatie-antwoord."));
+            }
+
+            return Result<MollieOrganizationInfo>.Ok(new MollieOrganizationInfo(payload.Id, payload.Name ?? string.Empty));
+        }
+        catch (HttpRequestException ex)
+        {
+            logger.LogError(ex, "Netwerkfout bij Mollie /organizations/me");
+            return Result<MollieOrganizationInfo>.Fail(new Error(
+                ErrorCodes.ExternalService,
+                "Kon Mollie niet bereiken."));
+        }
+    }
+
+    public async Task<Result> RevokeRefreshTokenAsync(
+        string refreshToken,
+        CancellationToken ct = default)
+    {
+        // Mollie revoke: DELETE /oauth2/tokens met body { "token": "...", "token_type_hint": "refresh_token" }
+        // Basic auth met client credentials (zelfde als token exchange).
+        using HttpRequestMessage request = new(HttpMethod.Delete, $"{_options.ApiBaseUrl}/oauth2/tokens");
+        request.Headers.Authorization = BuildBasicAuthHeader();
+        request.Content = JsonContent.Create(new
+        {
+            token = refreshToken,
+            token_type_hint = "refresh_token",
+        });
+
+        try
+        {
+            using HttpResponseMessage response = await httpClient.SendAsync(request, ct);
+            // Mollie returns 204 No Content op succes; 4xx als token al ingetrokken is.
+            // 4xx als al ingetrokken is acceptabel — disconnect blijft idempotent.
+            if (!response.IsSuccessStatusCode && (int)response.StatusCode < 400)
+            {
+                string body = await response.Content.ReadAsStringAsync(ct);
+                logger.LogWarning("Mollie token revoke gaf {Status}: {Body}", (int)response.StatusCode, body);
+                return Result.Fail(new Error(ErrorCodes.ExternalService, "Kon Mollie token niet intrekken."));
+            }
+            return Result.Ok();
+        }
+        catch (HttpRequestException ex)
+        {
+            logger.LogError(ex, "Netwerkfout bij Mollie token revoke");
+            return Result.Fail(new Error(ErrorCodes.ExternalService, "Kon Mollie niet bereiken."));
+        }
+    }
+
+    private async Task<Result<MollieTokenResponse>> PostTokenAsync(
+        IReadOnlyDictionary<string, string> form,
+        CancellationToken ct)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post, $"{_options.ApiBaseUrl}/oauth2/tokens");
+        request.Headers.Authorization = BuildBasicAuthHeader();
+        request.Content = new FormUrlEncodedContent(form);
+
+        try
+        {
+            using HttpResponseMessage response = await httpClient.SendAsync(request, ct);
+            string body = await response.Content.ReadAsStringAsync(ct);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                logger.LogWarning("Mollie /oauth2/tokens gaf {Status}: {Body}", (int)response.StatusCode, body);
+                return Result<MollieTokenResponse>.Fail(new Error(
+                    ErrorCodes.ExternalService,
+                    "Mollie OAuth-token uitwisseling is mislukt."));
+            }
+
+            MollieTokenPayload? payload = JsonSerializer.Deserialize<MollieTokenPayload>(body, JsonOptions);
+            if (payload is null || string.IsNullOrEmpty(payload.AccessToken) || string.IsNullOrEmpty(payload.RefreshToken))
+            {
+                return Result<MollieTokenResponse>.Fail(new Error(
+                    ErrorCodes.ExternalService,
+                    "Mollie gaf een onvolledig OAuth-token-antwoord."));
+            }
+
+            return Result<MollieTokenResponse>.Ok(new MollieTokenResponse(
+                payload.AccessToken,
+                payload.RefreshToken,
+                payload.ExpiresIn,
+                payload.TokenType ?? "bearer",
+                payload.Scope ?? string.Empty));
+        }
+        catch (HttpRequestException ex)
+        {
+            logger.LogError(ex, "Netwerkfout bij Mollie /oauth2/tokens");
+            return Result<MollieTokenResponse>.Fail(new Error(
+                ErrorCodes.ExternalService,
+                "Kon Mollie niet bereiken."));
+        }
+    }
+
+    private AuthenticationHeaderValue BuildBasicAuthHeader()
+    {
+        string raw = $"{_options.ClientId}:{_options.ClientSecret}";
+        string encoded = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(raw));
+        return new AuthenticationHeaderValue("Basic", encoded);
+    }
+
+    private sealed record MollieTokenPayload(
+        [property: JsonPropertyName("access_token")] string AccessToken,
+        [property: JsonPropertyName("refresh_token")] string RefreshToken,
+        [property: JsonPropertyName("expires_in")] int ExpiresIn,
+        [property: JsonPropertyName("token_type")] string? TokenType,
+        [property: JsonPropertyName("scope")] string? Scope);
+
+    private sealed record MollieOrganizationPayload(
+        [property: JsonPropertyName("id")] string Id,
+        [property: JsonPropertyName("name")] string? Name);
+}

--- a/backend/CoachOS.Infrastructure/Repositories/OAuthStateRepository.cs
+++ b/backend/CoachOS.Infrastructure/Repositories/OAuthStateRepository.cs
@@ -1,0 +1,38 @@
+using CoachOS.Domain.Entities;
+using CoachOS.Domain.Interfaces;
+using CoachOS.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace CoachOS.Infrastructure.Repositories;
+
+public class OAuthStateRepository(ApplicationDbContext context) : IOAuthStateRepository
+{
+    public async Task AddAsync(OAuthState state, CancellationToken ct = default)
+    {
+        await context.OAuthStates.AddAsync(state, ct);
+    }
+
+    public async Task<OAuthState?> GetByStateAsync(string state, CancellationToken ct = default)
+    {
+        return await context.OAuthStates
+            .FirstOrDefaultAsync(s => s.State == state, ct);
+    }
+
+    public Task DeleteAsync(OAuthState state, CancellationToken ct = default)
+    {
+        context.OAuthStates.Remove(state);
+        return Task.CompletedTask;
+    }
+
+    public async Task<int> DeleteExpiredAsync(DateTime utcNow, CancellationToken ct = default)
+    {
+        return await context.OAuthStates
+            .Where(s => s.ExpiresAt < utcNow)
+            .ExecuteDeleteAsync(ct);
+    }
+
+    public async Task SaveChangesAsync(CancellationToken ct = default)
+    {
+        await context.SaveChangesAsync(ct);
+    }
+}

--- a/backend/CoachOS.Infrastructure/Security/DataProtectionTokenProtector.cs
+++ b/backend/CoachOS.Infrastructure/Security/DataProtectionTokenProtector.cs
@@ -1,0 +1,22 @@
+using CoachOS.Domain.Interfaces;
+using Microsoft.AspNetCore.DataProtection;
+
+namespace CoachOS.Infrastructure.Security;
+
+/// <summary>
+/// <see cref="ITokenProtector"/>-implementatie bovenop ASP.NET Core DataProtection.
+/// Sleutels persisteren naar de filesystem zodat ze container-restarts overleven
+/// (zie <c>DependencyInjection</c> voor de path-configuratie).
+/// </summary>
+public class DataProtectionTokenProtector(IDataProtectionProvider provider) : ITokenProtector
+{
+    /// <summary>
+    /// Vaste purpose-string. Een latere wijziging maakt bestaande tokens onleesbaar,
+    /// dus enkel bumpen samen met een token-rotatie of migratiestrategie.
+    /// </summary>
+    private readonly IDataProtector _protector = provider.CreateProtector("CoachOS.Mollie.OAuth.v1");
+
+    public string Protect(string plaintext) => _protector.Protect(plaintext);
+
+    public string Unprotect(string protectedData) => _protector.Unprotect(protectedData);
+}

--- a/backend/CoachOS.Tests/Services/MollieConnectServiceTests.cs
+++ b/backend/CoachOS.Tests/Services/MollieConnectServiceTests.cs
@@ -1,0 +1,299 @@
+using CoachOS.Application.Configuration;
+using CoachOS.Application.MollieConnect;
+using CoachOS.Application.MollieConnect.DTOs;
+using CoachOS.Domain.Entities;
+using CoachOS.Domain.Interfaces;
+using CoachOS.Domain.Models;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+
+namespace CoachOS.Tests.Services;
+
+[TestFixture]
+public class MollieConnectServiceTests
+{
+    private Mock<IMollieClient> _mollie = null!;
+    private Mock<IMollieConnectionRepository> _connections = null!;
+    private Mock<IOAuthStateRepository> _states = null!;
+    private Mock<ITokenProtector> _protector = null!;
+    private FixedTimeProvider _time = null!;
+    private MollieConnectService _sut = null!;
+
+    private static readonly Guid OrgId = Guid.NewGuid();
+    private static readonly DateTime Now = new(2026, 5, 20, 12, 0, 0, DateTimeKind.Utc);
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mollie = new Mock<IMollieClient>();
+        _connections = new Mock<IMollieConnectionRepository>();
+        _states = new Mock<IOAuthStateRepository>();
+        _protector = new Mock<ITokenProtector>();
+        _protector.Setup(p => p.Protect(It.IsAny<string>()))
+            .Returns<string>(s => $"enc({s})");
+        _protector.Setup(p => p.Unprotect(It.IsAny<string>()))
+            .Returns<string>(s => s.StartsWith("enc(") ? s.Substring(4, s.Length - 5) : s);
+        _time = new FixedTimeProvider(Now);
+
+        IOptions<MollieOptions> options = Options.Create(new MollieOptions
+        {
+            ClientId = "test_client",
+            ClientSecret = "test_secret",
+            OAuthBaseUrl = "https://my.mollie.example",
+            ApiBaseUrl = "https://api.mollie.example",
+            Scopes = "payments.read payments.write organizations.read",
+        });
+
+        _sut = new MollieConnectService(
+            _mollie.Object,
+            _connections.Object,
+            _states.Object,
+            _protector.Object,
+            options,
+            _time,
+            NullLogger<MollieConnectService>.Instance);
+    }
+
+    [Test]
+    public async Task StartAsync_GeneratesStateAndAuthorizationUrl()
+    {
+        OAuthState? captured = null;
+        _states.Setup(s => s.AddAsync(It.IsAny<OAuthState>(), It.IsAny<CancellationToken>()))
+            .Callback<OAuthState, CancellationToken>((s, _) => captured = s)
+            .Returns(Task.CompletedTask);
+
+        Result<StartConnectResponse> result = await _sut.StartAsync(
+            OrgId, "https://app.example/api/oauth/mollie/callback");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.AuthorizationUrl.Should().StartWith("https://my.mollie.example/oauth2/authorize?");
+        result.Value!.AuthorizationUrl.Should().Contain("client_id=test_client");
+        result.Value!.AuthorizationUrl.Should().Contain("response_type=code");
+
+        captured.Should().NotBeNull();
+        captured!.OrganizationId.Should().Be(OrgId);
+        captured.State.Should().NotBeNullOrEmpty();
+        captured.ExpiresAt.Should().Be(Now.AddMinutes(15));
+
+        _states.Verify(s => s.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task StartAsync_MissingClientId_ReturnsExternalServiceError()
+    {
+        IOptions<MollieOptions> options = Options.Create(new MollieOptions
+        {
+            ClientId = string.Empty,
+            ClientSecret = "x",
+        });
+        MollieConnectService sut = new(
+            _mollie.Object, _connections.Object, _states.Object, _protector.Object,
+            options, _time, NullLogger<MollieConnectService>.Instance);
+
+        Result<StartConnectResponse> result = await sut.StartAsync(OrgId, "https://x/");
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors[0].Code.Should().Be(ErrorCodes.ExternalService);
+        _states.Verify(s => s.AddAsync(It.IsAny<OAuthState>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleCallbackAsync_UnknownState_ReturnsUnauthorized()
+    {
+        _states.Setup(s => s.GetByStateAsync("nope", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((OAuthState?)null);
+
+        Result<Guid> result = await _sut.HandleCallbackAsync("code", "nope", "https://x/");
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors[0].Code.Should().Be(ErrorCodes.Unauthorized);
+        _mollie.VerifyNoOtherCalls();
+    }
+
+    [Test]
+    public async Task HandleCallbackAsync_ExpiredState_DeletesAndFails()
+    {
+        OAuthState expired = new()
+        {
+            OrganizationId = OrgId,
+            State = "abc",
+            ExpiresAt = Now.AddMinutes(-1),
+        };
+        _states.Setup(s => s.GetByStateAsync("abc", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expired);
+
+        Result<Guid> result = await _sut.HandleCallbackAsync("code", "abc", "https://x/");
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors[0].Code.Should().Be(ErrorCodes.Unauthorized);
+        _states.Verify(s => s.DeleteAsync(expired, It.IsAny<CancellationToken>()), Times.Once);
+        _mollie.VerifyNoOtherCalls();
+    }
+
+    [Test]
+    public async Task HandleCallbackAsync_ValidFlow_SavesEncryptedConnection()
+    {
+        OAuthState live = new()
+        {
+            OrganizationId = OrgId,
+            State = "good",
+            ExpiresAt = Now.AddMinutes(5),
+        };
+        _states.Setup(s => s.GetByStateAsync("good", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(live);
+
+        _mollie.Setup(m => m.ExchangeCodeForTokenAsync("code", "https://x/", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<MollieTokenResponse>.Ok(new MollieTokenResponse(
+                AccessToken: "access-1",
+                RefreshToken: "refresh-1",
+                ExpiresInSeconds: 3600,
+                TokenType: "bearer",
+                Scope: "payments.read")));
+
+        _mollie.Setup(m => m.GetOrganizationAsync("access-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<MollieOrganizationInfo>.Ok(new MollieOrganizationInfo("org_123", "Demo Club")));
+
+        MollieConnection? saved = null;
+        _connections.Setup(c => c.AddAsync(It.IsAny<MollieConnection>(), It.IsAny<CancellationToken>()))
+            .Callback<MollieConnection, CancellationToken>((c, _) => saved = c)
+            .Returns(Task.CompletedTask);
+
+        Result<Guid> result = await _sut.HandleCallbackAsync("code", "good", "https://x/");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(OrgId);
+
+        // Bestaande connectie (her-connect-scenario) wordt eerst opgeruimd.
+        _connections.Verify(c => c.DeleteByOrganizationAsync(OrgId, It.IsAny<CancellationToken>()), Times.Once);
+
+        saved.Should().NotBeNull();
+        saved!.OrganizationId.Should().Be(OrgId);
+        saved.MollieOrganizationId.Should().Be("org_123");
+        saved.MollieOrganizationName.Should().Be("Demo Club");
+        saved.AccessTokenEncrypted.Should().Be("enc(access-1)");
+        saved.RefreshTokenEncrypted.Should().Be("enc(refresh-1)");
+        saved.AccessTokenExpiresAt.Should().Be(Now.AddSeconds(3600));
+        saved.ConnectedAt.Should().Be(Now);
+
+        _states.Verify(s => s.DeleteAsync(live, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task HandleCallbackAsync_TokenExchangeFails_DeletesStateAndPropagatesError()
+    {
+        OAuthState live = new()
+        {
+            OrganizationId = OrgId,
+            State = "good",
+            ExpiresAt = Now.AddMinutes(5),
+        };
+        _states.Setup(s => s.GetByStateAsync("good", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(live);
+        _mollie.Setup(m => m.ExchangeCodeForTokenAsync("code", "https://x/", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<MollieTokenResponse>.Fail(new Error(ErrorCodes.ExternalService, "boom")));
+
+        Result<Guid> result = await _sut.HandleCallbackAsync("code", "good", "https://x/");
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors[0].Code.Should().Be(ErrorCodes.ExternalService);
+        _states.Verify(s => s.DeleteAsync(live, It.IsAny<CancellationToken>()), Times.Once);
+        _connections.Verify(c => c.AddAsync(It.IsAny<MollieConnection>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task DisconnectAsync_NotConnected_IsNoop()
+    {
+        _connections.Setup(c => c.GetByOrganizationAsync(OrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MollieConnection?)null);
+
+        Result result = await _sut.DisconnectAsync(OrgId);
+
+        result.IsSuccess.Should().BeTrue();
+        _mollie.Verify(m => m.RevokeRefreshTokenAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _connections.Verify(c => c.DeleteByOrganizationAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task DisconnectAsync_Connected_RevokesAndDeletes()
+    {
+        MollieConnection existing = new()
+        {
+            OrganizationId = OrgId,
+            RefreshTokenEncrypted = "enc(refresh-x)",
+            AccessTokenEncrypted = "enc(access-x)",
+            MollieOrganizationId = "org_x",
+        };
+        _connections.Setup(c => c.GetByOrganizationAsync(OrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        _mollie.Setup(m => m.RevokeRefreshTokenAsync("refresh-x", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Ok());
+
+        Result result = await _sut.DisconnectAsync(OrgId);
+
+        result.IsSuccess.Should().BeTrue();
+        _mollie.Verify(m => m.RevokeRefreshTokenAsync("refresh-x", It.IsAny<CancellationToken>()), Times.Once);
+        _connections.Verify(c => c.DeleteByOrganizationAsync(OrgId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task DisconnectAsync_RevokeFails_StillDeletesLocally()
+    {
+        MollieConnection existing = new()
+        {
+            OrganizationId = OrgId,
+            RefreshTokenEncrypted = "enc(refresh-x)",
+            AccessTokenEncrypted = "enc(access-x)",
+        };
+        _connections.Setup(c => c.GetByOrganizationAsync(OrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        _mollie.Setup(m => m.RevokeRefreshTokenAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Fail(new Error(ErrorCodes.ExternalService, "mollie down")));
+
+        Result result = await _sut.DisconnectAsync(OrgId);
+
+        result.IsSuccess.Should().BeTrue();
+        _connections.Verify(c => c.DeleteByOrganizationAsync(OrgId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task GetStatusAsync_NotConnected_ReturnsFalse()
+    {
+        _connections.Setup(c => c.GetByOrganizationReadOnlyAsync(OrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MollieConnection?)null);
+
+        Result<MollieConnectionStatusDto> result = await _sut.GetStatusAsync(OrgId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Connected.Should().BeFalse();
+        result.Value!.MollieOrganizationName.Should().BeNull();
+    }
+
+    [Test]
+    public async Task GetStatusAsync_Connected_ReturnsOrganizationName()
+    {
+        MollieConnection existing = new()
+        {
+            OrganizationId = OrgId,
+            MollieOrganizationName = "Demo Club",
+            ConnectedAt = Now,
+        };
+        _connections.Setup(c => c.GetByOrganizationReadOnlyAsync(OrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+
+        Result<MollieConnectionStatusDto> result = await _sut.GetStatusAsync(OrgId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Connected.Should().BeTrue();
+        result.Value!.MollieOrganizationName.Should().Be("Demo Club");
+        result.Value!.ConnectedAt.Should().Be(Now);
+    }
+
+    /// <summary>Eenvoudige test-implementatie van <see cref="TimeProvider"/>.</summary>
+    private sealed class FixedTimeProvider(DateTime utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => new(utcNow, TimeSpan.Zero);
+    }
+}


### PR DESCRIPTION
## Summary

- **MollieOptions** configuration class binding `Mollie:` section (ClientId, ClientSecret, WebhookBaseUrl, RedirectUri, ApiBaseUrl, OAuthBaseUrl, Scopes)
- **MollieClient** HTTP wrapper for OAuth token exchange/refresh, org info fetch (`GET /v2/organizations/me`), and token revocation. Uses `IHttpClientFactory`, basic auth for token endpoints, Bearer for resource endpoints
- **DataProtectionTokenProtector** at-rest encryption of Mollie tokens via ASP.NET Core DataProtection with persistent file-system keys
- **MollieConnectService** orchestrates OAuth flow: state creation + auth URL generation, callback validation + code exchange + org fetch + upsert, disconnect with revocation (idempotent), status check
- **4 REST endpoints** under `/api/mollie-connect/*` (admin-only) and `/api/oauth/mollie/callback` (anonymous server-side redirect)

## Why split this way

Backend foundation is isolated in this PR so PR #3 can focus purely on the React settings UI consuming a stable, tested API contract. Tests (MollieConnectServiceTests) verify state lifecycle, token encryption, and error paths without needing frontend code.

## Test plan

- [ ] `dotnet build CoachOS.slnx` succeeds (0 warnings)
- [ ] `dotnet test CoachOS.slnx` shows 183 passed (172 existing + 11 new MollieConnectService tests)
- [ ] After merging: rebuild backend container (`docker-compose up -d --build backend`), confirm Swagger shows 4 new endpoints under `/mollie-connect` and `/oauth/mollie/callback`
- [ ] `GET /api/mollie-connect/status` with admin JWT returns `{"connected":false,...}` (no Mollie connection yet)
- [ ] `POST /api/mollie-connect/start` returns clear error (502 + Dutch message) when `Mollie__ClientId` env var is missing
- [ ] With real `Mollie__ClientId` + `Mollie__ClientSecret` populated (Scaleway secret), full OAuth flow can be driven from Postman: `start` → browser OAuth → `callback` → `status` now `{"connected":true,...}`

## Production note

`DataProtection:KeyDirectory` defaults to a temp directory locally but **must** be overridden to a persistent volume in production (Scaleway env var) before go-live — otherwise encrypted Mollie tokens become unreadable across container restarts.

## Next

PR #3 adds the frontend settings UI (lib/api/mollieConnect.ts + dashboard/settings/mollie-section.tsx); depends on this PR.