### PR TITLE
fix(infra): persist DataProtection keystore for mollie tokens

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -29,6 +29,13 @@ WORKDIR /app
 COPY --from=build --chown=app:app /app .
 RUN chown app:app /app
 
+# DataProtection keystore. Mollie OAuth tokens are encrypted at rest with keys
+# stored here; container restarts must not invalidate them. In production a
+# named docker volume is mounted on this path (see infrastructure/docker-compose.yml).
+# Pre-creating the dir with app ownership ensures the non-root user can write
+# when docker creates an empty named volume on first start.
+RUN mkdir -p /data-protection-keys && chown app:app /data-protection-keys
+
 USER app
 
 ENV ASPNETCORE_URLS=http://+:5142

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -26,6 +26,13 @@ services:
       App__ConfirmationBaseUrl: https://app.coach-os.be/confirmation
       App__StudentMagicLinkBaseUrl: https://app.coach-os.be/auth/magic
       App__StandaloneLessonInvitationBaseUrl: https://app.coach-os.be/invitation
+      # DataProtection keystore directory. Backed by the data_protection_keys
+      # named volume below so encrypted Mollie OAuth tokens survive container
+      # restarts. Path matches the chown in backend/Dockerfile.
+      DataProtection__KeyDirectory: /data-protection-keys
+
+    volumes:
+      - data_protection_keys:/data-protection-keys
 
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/health"]
@@ -159,3 +166,11 @@ services:
 networks:
   coach-os-network:
     driver: bridge
+
+volumes:
+  # Persistent DataProtection keystore. Mollie OAuth tokens are encrypted at
+  # rest with keys stored here; loss of this volume invalidates every active
+  # club's Mollie connection (they would each need to re-authorize). Back this
+  # up with the same cadence as critical app state.
+  data_protection_keys:
+    driver: local


### PR DESCRIPTION
## Summary

- **Problem:** Mollie OAuth tokens are encrypted at rest using ASP.NET Core DataProtection. Container restarts generate fresh keys, invalidating all encrypted tokens and forcing every connected club to re-authorize.
- **Fix:** Mount a persistent named volume at `/data-protection-keys` (in production compose only) and configure the api service to use it. Dockerfile pre-creates the directory with correct ownership so the non-root runtime user can write keys.
- **Impact:** Seamless deployments without disrupting active Mollie connections.

## Test Plan

- [ ] `docker compose -f infrastructure/docker-compose.yml config` shows the api service with `volumes:` entry mounting `data_protection_keys` at `/data-protection-keys` and the `DataProtection__KeyDirectory` env var
- [ ] After deploy: `docker exec coach-os-api ls -la /data-protection-keys` shows the directory owned by `app:app`
- [ ] After deploy + first Mollie connect + container restart: existing `MollieConnection` rows still decrypt successfully (verifiable once PR #121 + PR #3 are live)
- [ ] `docker volume inspect coach-os_data_protection_keys` shows the named volume exists

## Recommended Merge Order

Merge this PR first, then PR #121. The env var is a no-op until PR #121's `DependencyInjection.cs` reads it.

## Notes

Local dev compose (`docker-compose.yml` at repo root) is intentionally untouched — dev keeps using the temp-dir fallback, which is fine because dev re-seeds frequently.