### PR TITLE
chore(dev): mollie OAuth env passthrough for local testing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Lokale ontwikkelings-secrets voor docker-compose. Kopieer naar `.env` en
+# vul de waarden in. `.env` is gitignored — commit nooit echte secrets.
+#
+# Productie haalt deze waarden uit Scaleway Secret Manager via Terraform;
+# dit bestand is enkel relevant voor `docker-compose up` op je laptop.
+
+# ── Mollie Connect (OAuth client credentials) ───────────────────────────────
+# Hetzelfde Mollie partner-account dat in productie wordt gebruikt; Mollie
+# heeft `http://localhost:5142/api/oauth/mollie/callback` al als geldige
+# redirect URI geregistreerd zodat de OAuth flow lokaal werkt.
+# Haal de waarden uit Scaleway Secret Manager:
+#   scw secret secret-version access-by-path path=/Mollie__ClientId revision=latest
+#   scw secret secret-version access-by-path path=/Mollie__ClientSecret revision=latest
+MOLLIE_CLIENT_ID=
+MOLLIE_CLIENT_SECRET=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,12 @@ docker-compose up -d                          # PostgreSQL + pgAdmin
 cd backend/CoachOS.API && dotnet run          # API on http://localhost:5142
 cd frontend && bun dev                        # Frontend on http://localhost:5317
 
+# Mollie OAuth lokaal testen (optioneel)
+# Vul MOLLIE_CLIENT_ID + MOLLIE_CLIENT_SECRET in .env (zie .env.example);
+# rebuild dan de backend container zodat de env vars in worden gepikt:
+#   docker-compose up -d --build backend
+# Mollie heeft localhost:5142/api/oauth/mollie/callback al als redirect URI.
+
 # Build
 cd backend && dotnet build CoachOS.slnx
 cd frontend && bun run build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,13 @@ services:
       Email__FromName: "CoachOS"
       Email__Username: ""
       Email__Password: ""
+      # Mollie Connect — leeg laten betekent dat de "Verbind met Mollie"-knop
+      # een duidelijke "niet geconfigureerd"-fout teruggeeft. Voor lokaal
+      # testen: zet MOLLIE_CLIENT_ID en MOLLIE_CLIENT_SECRET in .env (zie
+      # .env.example). Mollie heeft localhost:5142/api/oauth/mollie/callback
+      # al als redirect URI geregistreerd voor de Coach OS OAuth app.
+      Mollie__ClientId: "${MOLLIE_CLIENT_ID:-}"
+      Mollie__ClientSecret: "${MOLLIE_CLIENT_SECRET:-}"
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Adds `MOLLIE_CLIENT_ID` and `MOLLIE_CLIENT_SECRET` env var passthroughs in `docker-compose.yml` to the backend service
- Includes `.env.example` template documenting where to fetch these values from Scaleway Secret Manager
- No app code changes; enables developers to test the full Mollie OAuth flow locally without production redeployment

## Test plan
- [ ] `docker compose config --quiet` returns 0
- [ ] Existing `docker-compose up -d` without `.env` still works (env vars resolve to empty string)
- [ ] After populating `.env` + `docker-compose up -d --build backend`, container env shows `Mollie__ClientId` set: `docker exec coachos_backend env | grep -i mollie`
- [ ] OAuth flow works end-to-end: status → start → my.mollie.com OAuth → callback → status connected

## Safety
`.env` is already gitignored; this PR only adds placeholders + the `.env.example` template; no real secret values committed.