### PR TITLE
infra(secrets): declare Mollie__RedirectUri as manual secret

### DIFF
--- a/infrastructure/SECRETS.md
+++ b/infrastructure/SECRETS.md
@@ -53,6 +53,11 @@ TEM only issues SMTP credentials after DKIM/SPF DNS verification has propagated.
 | `Email__FromName` | ✓ Terraform | `CoachOS` |
 | `Email__Username` | **manual** | After Scaleway TEM verifies the domain, generate API key with `TransactionalEmail` permission, copy to a new secret version |
 | `Email__Password` | **manual** | The secret half of the same API key |
+| `Mollie__WebhookBaseUrl` | ✓ Terraform | `https://app.<domain_name>` |
+| `Mollie__ClientId` | **manual** | From my.mollie.com → Developers → OAuth applications |
+| `Mollie__ClientSecret` | **manual** | Same place, shown once on creation |
+| `Mollie__RedirectUri` | **manual** | `https://app.<domain_name>/api/oauth/mollie/callback` — must match Mollie dashboard exactly |
+| `SuperAdmin__Email` | **manual** | Email of the first system-level super admin (promoted at API startup) |
 
 ### Manual TEM creds setup
 

--- a/infrastructure/terraform/secrets.tf
+++ b/infrastructure/terraform/secrets.tf
@@ -104,3 +104,19 @@ resource "scaleway_secret" "mollie_client_secret" {
   description = "Mollie Connect OAuth client secret — manueel ingevuld na Mollie onboarding"
   tags        = ["coach-os", "manual", "mollie"]
 }
+
+# Mollie__RedirectUri — overschrijft de runtime-afgeleide redirect URI
+# (HttpContext.Request.Scheme + Host). Nodig achter de nginx-proxy omdat
+# ASP.NET anders `http://` ziet ipv `https://` en Mollie de redirect exact
+# matcht. Vul in via Scaleway console of:
+#   scw secret secret-version create <secret_id> \
+#     data="https://app.<domain_name>/api/oauth/mollie/callback"
+# De waarde MOET letterlijk overeenkomen met wat in het Mollie dashboard
+# als redirect URI staat geregistreerd.
+resource "scaleway_secret" "mollie_redirect_uri" {
+  project_id  = var.scw_project_id
+  region      = var.scw_region
+  name        = "Mollie__RedirectUri"
+  description = "Mollie Connect OAuth redirect URI — manueel ingevuld, moet exact matchen met Mollie dashboard"
+  tags        = ["coach-os", "manual", "mollie"]
+}


### PR DESCRIPTION
## Summary
- Adds `Mollie__RedirectUri` as a manually-filled Scaleway secret so the production OAuth redirect URI is set explicitly (`https://app.<domain>/api/oauth/mollie/callback`) instead of being derived from `HttpContext.Request.Scheme`, which reads as `http://` behind the nginx proxy and gets rejected by Mollie.
- Adds the four Mollie secrets and `SuperAdmin__Email` to `SECRETS.md` — these were declared in Terraform but missing from the checklist.

## After merge
1. `tofu apply` creates the empty secret container
2. Fill the value: `scw secret version create secret-id=$(scw secret secret list name=Mollie__RedirectUri -o json | jq -r '.[0].id') data="https://app.coach-os.be/api/oauth/mollie/callback"`
3. Register the exact same URI in the Mollie dashboard → Developers → OAuth applications
4. Restart the API: `ssh root@$VPS_IP "cd /app && docker compose restart api"`

## Follow-up (separate PR)
Add `UseForwardedHeaders` middleware to `Program.cs` so other URL-generation behind nginx (password reset, confirmation links) sees the correct `https` scheme too.

## Test plan
- [ ] `tofu plan` shows only the new `scaleway_secret.mollie_redirect_uri` resource
- [ ] `tofu apply` succeeds
- [ ] Fill secret value via scw CLI
- [ ] Restart API, hit `/api/oauth/mollie/start`, verify the returned authorize URL contains `redirect_uri=https%3A%2F%2Fapp.coach-os.be...`
- [ ] Mollie authorize page loads without "redirect URI does not match" error