### PR TITLE
fix(lessonserie): align duplicate-slot guard with unique index (#140)

### DIFF
--- a/backend/CoachOS.Application/LessonSerie/LessonSerieService.cs
+++ b/backend/CoachOS.Application/LessonSerie/LessonSerieService.cs
@@ -95,9 +95,12 @@ public class LessonSerieService(
         if (trainerError is not null)
             return Result<Guid>.Fail(trainerError);
 
-        // Reject duplicate weekly template entries (same day + time + court = same slot)
-        List<(int DayOfWeek, string StartTime, string EndTime, string CourtName)> duplicates = request.WeeklyTemplate
-            .GroupBy(t => (t.DayOfWeek, t.StartTime, t.EndTime, CourtName: t.CourtName ?? ""))
+        // Reject duplicate weekly template entries (same day + start time + court = same slot).
+        // The key MUST match the unique index IX_WeeklyTemplateEntries_LessonSerieId_DayOfWeek_StartTime_CourtName
+        // (which does NOT include EndTime); otherwise a same-start/different-end collision slips past this guard
+        // and surfaces as a raw DbUpdateException → HTTP 500 instead of this clean validation error.
+        var duplicates = request.WeeklyTemplate
+            .GroupBy(t => (t.DayOfWeek, t.StartTime, CourtName: t.CourtName ?? ""))
             .Where(g => g.Count() > 1)
             .Select(g => g.Key)
             .ToList();
@@ -105,8 +108,8 @@ public class LessonSerieService(
         if (duplicates.Count > 0)
         {
             string[] dayNames = ["ma", "di", "wo", "do", "vr", "za", "zo"];
-            string slots = string.Join(", ", duplicates.Select(d =>
-                $"{dayNames[d.DayOfWeek]} {d.StartTime}–{d.EndTime}" + (d.CourtName != "" ? $" ({d.CourtName})" : "")));
+            var slots = string.Join(", ", duplicates.Select(d =>
+                $"{dayNames[d.DayOfWeek]} {d.StartTime}" + (d.CourtName != "" ? $" ({d.CourtName})" : "")));
             return Result<Guid>.Fail(new Error(ErrorCodes.Validation,
                 $"Dubbele tijdsloten in weekindeling: {slots}. Verwijder de duplicaten."));
         }

--- a/backend/CoachOS.Tests/Services/LessonSerieServiceTests.cs
+++ b/backend/CoachOS.Tests/Services/LessonSerieServiceTests.cs
@@ -702,6 +702,101 @@ public class LessonSerieServiceTests
     }
 
     [Test]
+    public async Task CreateAsync_ReturnsValidation_WhenWeeklyTemplateHasExactDuplicateSlot()
+    {
+        CreateLessonSerieRequest request = new()
+        {
+            Name = "Dubbele slot",
+            Price = 100m,
+            StartDate = "2026-06-01",
+            EndDate = "2026-08-31",
+            TennisClubId = ClubId,
+            WeeklyTemplate =
+            [
+                new WeeklyTemplateEntryRequest { DayOfWeek = 0, StartTime = "10:00", EndTime = "11:00", TrainerId = TrainerId, CourtName = "Baan 1", MaxStudents = 4 },
+                new WeeklyTemplateEntryRequest { DayOfWeek = 0, StartTime = "10:00", EndTime = "11:00", TrainerId = TrainerId, CourtName = "Baan 1", MaxStudents = 4 },
+            ],
+        };
+
+        _tennisClubRepo
+            .Setup(r => r.ExistsAsync(ClubId, OrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await _service.CreateAsync(OrgId, request);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainSingle(e => e.Code == ErrorCodes.Validation);
+        _lessonSeriesRepo.Verify(r => r.AddAsync(It.IsAny<LessonSerie>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // Regression (issue #140): two slots on the same day/start/court with DIFFERENT end times used to
+    // slip past the duplicate guard (which keyed on EndTime) and hit the unique index
+    // IX_WeeklyTemplateEntries_LessonSerieId_DayOfWeek_StartTime_CourtName → DbUpdateException → HTTP 500.
+    // The guard must now reject it cleanly, matching the index (no EndTime in the key).
+    [Test]
+    public async Task CreateAsync_ReturnsValidation_WhenSlotsShareDayStartAndCourtButDifferentEnd()
+    {
+        CreateLessonSerieRequest request = new()
+        {
+            Name = "Zelfde start, andere eindtijd",
+            Price = 100m,
+            StartDate = "2026-06-01",
+            EndDate = "2026-08-31",
+            TennisClubId = ClubId,
+            WeeklyTemplate =
+            [
+                new WeeklyTemplateEntryRequest { DayOfWeek = 0, StartTime = "10:00", EndTime = "11:00", TrainerId = TrainerId, CourtName = "Baan 1", MaxStudents = 4 },
+                new WeeklyTemplateEntryRequest { DayOfWeek = 0, StartTime = "10:00", EndTime = "12:00", TrainerId = TrainerId, CourtName = "Baan 1", MaxStudents = 4 },
+            ],
+        };
+
+        _tennisClubRepo
+            .Setup(r => r.ExistsAsync(ClubId, OrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await _service.CreateAsync(OrgId, request);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainSingle(e => e.Code == ErrorCodes.Validation);
+        _lessonSeriesRepo.Verify(r => r.AddAsync(It.IsAny<LessonSerie>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task CreateAsync_Succeeds_WhenSlotsShareDayAndStartButDifferentCourt()
+    {
+        CreateLessonSerieRequest request = new()
+        {
+            Name = "Parallelle banen",
+            Price = 100m,
+            StartDate = "2026-06-01",
+            EndDate = "2026-08-31",
+            TennisClubId = ClubId,
+            WeeklyTemplate =
+            [
+                new WeeklyTemplateEntryRequest { DayOfWeek = 0, StartTime = "10:00", EndTime = "11:00", TrainerId = TrainerId, CourtName = "Baan 1", MaxStudents = 4 },
+                new WeeklyTemplateEntryRequest { DayOfWeek = 0, StartTime = "10:00", EndTime = "11:00", TrainerId = TrainerId, CourtName = "Baan 2", MaxStudents = 4 },
+            ],
+            Lessons =
+            [
+                new CreateLessonRequest { TrainerId = TrainerId, Date = "2026-06-01", StartTime = "10:00", EndTime = "11:00", CourtName = "Baan 1", MaxStudents = 4 },
+            ],
+        };
+
+        _tennisClubRepo
+            .Setup(r => r.ExistsAsync(ClubId, OrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _lessonSeriesRepo
+            .Setup(r => r.AddAsync(It.IsAny<LessonSerie>(), It.IsAny<CancellationToken>()))
+            .Callback<LessonSerie, CancellationToken>((s, _) => s.Id = Guid.NewGuid())
+            .Returns(Task.CompletedTask);
+
+        var result = await _service.CreateAsync(OrgId, request);
+
+        result.IsSuccess.Should().BeTrue();
+        _lessonSeriesRepo.Verify(r => r.AddAsync(It.IsAny<LessonSerie>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
     public async Task CreateAsync_PersistsMaxStudentsOnLesson()
     {
         LessonSerie? captured = null;


### PR DESCRIPTION
Two weekly-template slots on the same day/start/court but with different end times bypassed the duplicate guard (which keyed on EndTime) and hit the IX_WeeklyTemplateEntries_LessonSerieId_DayOfWeek_StartTime_CourtName unique index, surfacing as a DbUpdateException -> HTTP 500.

Drop EndTime from the guard's GroupBy key so it matches the index exactly; the case now returns the clean "Dubbele tijdsloten" validation error (400). Add regression tests for same-start/different-end, exact duplicate, and the parallel-different-court (allowed) cases.