### PR TITLE
fix(dialog): scroll dialog body so footer stays reachable on tall con…

### DIFF
--- a/frontend/app/(dashboard)/dashboard/lessons/new/_components/edit-week-dialog.tsx
+++ b/frontend/app/(dashboard)/dashboard/lessons/new/_components/edit-week-dialog.tsx
@@ -4,7 +4,9 @@ import { useState } from "react";
 import { useTranslations } from "next-intl";
 import {
   Dialog,
+  DialogBody,
   DialogContent,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -62,7 +64,7 @@ export function EditWeekDialog({
           </DialogTitle>
         </DialogHeader>
 
-        <div className="mt-2">
+        <DialogBody className="mt-2">
           <WeekTemplateBuilder
             slots={slots}
             onChange={setSlots}
@@ -73,9 +75,9 @@ export function EditWeekDialog({
             seriesEndDate={seriesEndDate}
             removeOnly
           />
-        </div>
+        </DialogBody>
 
-        <div className="flex gap-3 pt-4 border-t border-gray-100">
+        <DialogFooter className="gap-3 border-t border-gray-100 pt-4 sm:justify-stretch">
           <button
             type="button"
             onClick={onClose}
@@ -93,7 +95,7 @@ export function EditWeekDialog({
           >
             {t("saveWeek")}
           </button>
-        </div>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );

--- a/frontend/components/ui/dialog.tsx
+++ b/frontend/components/ui/dialog.tsx
@@ -61,7 +61,11 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+          // Flex column zodat header/footer shrink-0 kunnen blijven en de body kan scrollen
+          // wanneer de natuurlijke hoogte > 90vh zou worden. Voorkomt onbereikbare footer-knoppen.
+          // De body-laag is verantwoordelijk voor het scrollen: geef die `min-h-0 overflow-y-auto`
+          // (of gebruik <DialogBody>) zodat die binnen de beschikbare ruimte scrollt.
+          "fixed top-[50%] left-[50%] z-50 flex w-full max-w-[calc(100%-2rem)] max-h-[90vh] translate-x-[-50%] translate-y-[-50%] flex-col gap-4 overflow-hidden rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
           className
         )}
         {...props}
@@ -81,11 +85,23 @@ function DialogContent({
   )
 }
 
+function DialogBody({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-body"
+      // min-h-0 is nodig zodat dit flex-child kan krimpen i.p.v. de hele dialog
+      // voorbij max-h-[90vh] te duwen; flex-1 vult de resterende ruimte en scrollt.
+      className={cn("min-h-0 flex-1 overflow-y-auto", className)}
+      {...props}
+    />
+  )
+}
+
 function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="dialog-header"
-      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      className={cn("flex shrink-0 flex-col gap-2 text-center sm:text-left", className)}
       {...props}
     />
   )
@@ -103,7 +119,7 @@ function DialogFooter({
     <div
       data-slot="dialog-footer"
       className={cn(
-        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        "flex shrink-0 flex-col-reverse gap-2 sm:flex-row sm:justify-end",
         className
       )}
       {...props}
@@ -146,6 +162,7 @@ function DialogDescription({
 
 export {
   Dialog,
+  DialogBody,
   DialogClose,
   DialogContent,
   DialogDescription,


### PR DESCRIPTION
Replace the fragile :not([data-slot=...]) arbitrary-variant selectors — which Tailwind v4 doesn't reliably compile — with an explicit, reusable DialogBody component (min-h-0 flex-1 overflow-y-auto). The dialog now caps at max-h-[90vh] with a scrolling body and a pinned, always-visible footer.

Apply it in the week-edit dialog where long slot lists pushed the footer buttons off-screen.