### PR TITLE
feat(trainers): bewerk weekcapaciteit, naam en interne notitie

### DIFF
--- a/backend/CoachOS.API/Endpoints/Trainers/UpdateTrainerEndpoint.cs
+++ b/backend/CoachOS.API/Endpoints/Trainers/UpdateTrainerEndpoint.cs
@@ -1,0 +1,21 @@
+using CoachOS.API.Extensions;
+using CoachOS.API.Filters;
+using CoachOS.Application.Trainers;
+using CoachOS.Application.Trainers.DTOs;
+
+namespace CoachOS.API.Endpoints.Trainers;
+
+public class UpdateTrainerEndpoint : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPut("/trainers/{id:guid}", async (Guid id, UpdateTrainerRequest request, ITrainerService service, HttpContext ctx, CancellationToken ct) =>
+        {
+            var result = await service.UpdateAsync(id, ctx.GetOrganizationId(), request, ct);
+            return result.IsSuccess ? Results.NoContent() : result.ToErrorResult();
+        })
+        .RequireAuthorization(policy => policy.RequireRole("Admin"))
+        .AddEndpointFilter<ValidationFilter<UpdateTrainerRequest>>()
+        .WithTags("Trainers");
+    }
+}

--- a/backend/CoachOS.Application/Trainers/DTOs/TrainerDto.cs
+++ b/backend/CoachOS.Application/Trainers/DTOs/TrainerDto.cs
@@ -11,5 +11,6 @@ public class TrainerDto
     public int LessonSeriesCount { get; set; }
     public decimal CurrentWeekHoursBooked { get; set; }
     public int WeeklyCapacityHours { get; set; }
+    public string? Notes { get; set; }
     public DateTime CreatedAt { get; set; }
 }

--- a/backend/CoachOS.Application/Trainers/DTOs/UpdateTrainerRequest.cs
+++ b/backend/CoachOS.Application/Trainers/DTOs/UpdateTrainerRequest.cs
@@ -1,0 +1,9 @@
+namespace CoachOS.Application.Trainers.DTOs;
+
+public record UpdateTrainerRequest
+{
+    public string FirstName { get; init; } = string.Empty;
+    public string LastName { get; init; } = string.Empty;
+    public int WeeklyCapacityHours { get; init; }
+    public string? Notes { get; init; }
+}

--- a/backend/CoachOS.Application/Trainers/ITrainerService.cs
+++ b/backend/CoachOS.Application/Trainers/ITrainerService.cs
@@ -23,6 +23,12 @@ public interface ITrainerService
         Guid organizationId,
         CancellationToken ct = default);
 
+    Task<Result> UpdateAsync(
+        Guid trainerId,
+        Guid organizationId,
+        UpdateTrainerRequest request,
+        CancellationToken ct = default);
+
     Task<Result> ResendInviteAsync(
         Guid trainerId,
         Guid organizationId,

--- a/backend/CoachOS.Application/Trainers/Validators/UpdateTrainerRequestValidator.cs
+++ b/backend/CoachOS.Application/Trainers/Validators/UpdateTrainerRequestValidator.cs
@@ -1,0 +1,27 @@
+using CoachOS.Application.Common;
+using CoachOS.Application.Trainers.DTOs;
+using FluentValidation;
+
+namespace CoachOS.Application.Trainers.Validators;
+
+public class UpdateTrainerRequestValidator : AbstractValidator<UpdateTrainerRequest>
+{
+    public UpdateTrainerRequestValidator()
+    {
+        RuleFor(x => x.FirstName)
+            .NotEmpty().WithMessage("Voornaam is verplicht")
+            .MaximumLength(100).WithMessage("Voornaam mag maximaal 100 karakters zijn")
+            .Must(InputSanitizer.IsFreeOfHtml).WithMessage("Voornaam mag geen HTML of scripttekens bevatten");
+
+        RuleFor(x => x.LastName)
+            .NotEmpty().WithMessage("Achternaam is verplicht")
+            .MaximumLength(100).WithMessage("Achternaam mag maximaal 100 karakters zijn")
+            .Must(InputSanitizer.IsFreeOfHtml).WithMessage("Achternaam mag geen HTML of scripttekens bevatten");
+
+        RuleFor(x => x.WeeklyCapacityHours)
+            .InclusiveBetween(1, 80).WithMessage("Weekcapaciteit moet tussen 1 en 80 uur zijn");
+
+        RuleFor(x => x.Notes)
+            .MaximumLength(1000).WithMessage("Notitie mag maximaal 1000 karakters zijn");
+    }
+}

--- a/backend/CoachOS.Domain/Entities/OrganizationMembership.cs
+++ b/backend/CoachOS.Domain/Entities/OrganizationMembership.cs
@@ -18,6 +18,17 @@ public class OrganizationMembership : BaseEntity
 
     public bool IsActive { get; set; } = true;
 
+    /// <summary>
+    /// Maximale weekcapaciteit (uren) van deze trainer voor déze club.
+    /// Voedt de noemer van de weekbelasting-balk. Per club instelbaar.
+    /// </summary>
+    public int WeeklyCapacityHours { get; set; } = 16;
+
+    /// <summary>
+    /// Interne notitie voor het clubbeheer — niet zichtbaar voor de trainer of leerlingen.
+    /// </summary>
+    public string? Notes { get; set; }
+
     public DateTime JoinedAt { get; set; }
 
     public Organization Organization { get; set; } = null!;

--- a/backend/CoachOS.Infrastructure/Identity/TrainerService.cs
+++ b/backend/CoachOS.Infrastructure/Identity/TrainerService.cs
@@ -190,6 +190,42 @@ public class TrainerService(
         return Result<List<TrainerDto>>.Ok(trainers);
     }
 
+    public async Task<Result> UpdateAsync(
+        Guid trainerId,
+        Guid organizationId,
+        UpdateTrainerRequest request,
+        CancellationToken ct = default)
+    {
+        // Capaciteit + notitie zijn per club → op het membership.
+        // Werkt voor Trainer- én Admin-rol zodat meecoachende admins en
+        // openstaande uitnodigingen (IsActive == false) ook bewerkbaar zijn.
+        OrganizationMembership? membership = await context.OrganizationMemberships
+            .FirstOrDefaultAsync(m => m.UserId == trainerId
+                && m.OrganizationId == organizationId
+                && (m.Role == UserRole.Trainer || m.Role == UserRole.Admin), ct);
+
+        if (membership is null)
+            return Result.Fail(new Error(ErrorCodes.NotFound, "Trainer niet gevonden in deze organisatie."));
+
+        // Naam is globaal → op de user. Alleen FirstName/LastName (geen
+        // Identity-gevoelige velden), dus rechtstreeks via context.Users zodat
+        // membership + user in één SaveChanges/transactie meegaan. UpdatedAt
+        // wordt automatisch gestempeld in SaveChangesAsync.
+        ApplicationUser? user = await context.Users
+            .FirstOrDefaultAsync(u => u.Id == trainerId, ct);
+
+        if (user is null)
+            return Result.Fail(new Error(ErrorCodes.NotFound, "Gebruiker niet gevonden."));
+
+        membership.WeeklyCapacityHours = request.WeeklyCapacityHours;
+        membership.Notes = string.IsNullOrWhiteSpace(request.Notes) ? null : request.Notes.Trim();
+        user.FirstName = request.FirstName.Trim();
+        user.LastName = request.LastName.Trim();
+
+        await context.SaveChangesAsync(ct);
+        return Result.Ok();
+    }
+
     public async Task<Result> ResendInviteAsync(
         Guid trainerId,
         Guid organizationId,

--- a/backend/CoachOS.Infrastructure/Identity/TrainerService.cs
+++ b/backend/CoachOS.Infrastructure/Identity/TrainerService.cs
@@ -152,7 +152,8 @@ public class TrainerService(
                 CreatedAt = u.CreatedAt,
                 LessonSeriesCount = context.LessonSeries
                     .Count(ls => ls.Lessons.Any(l => l.TrainerId == u.Id) && ls.OrganizationId == organizationId && ls.IsActive),
-                WeeklyCapacityHours = 16,
+                WeeklyCapacityHours = m.WeeklyCapacityHours,
+                Notes = m.Notes,
             };
 
         List<TrainerDto> trainers = await query.ToListAsync(ct);

--- a/backend/CoachOS.Infrastructure/Migrations/20260607150733_AddTrainerCapacityAndNotes.Designer.cs
+++ b/backend/CoachOS.Infrastructure/Migrations/20260607150733_AddTrainerCapacityAndNotes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CoachOS.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CoachOS.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260607150733_AddTrainerCapacityAndNotes")]
+    partial class AddTrainerCapacityAndNotes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/CoachOS.Infrastructure/Migrations/20260607150733_AddTrainerCapacityAndNotes.cs
+++ b/backend/CoachOS.Infrastructure/Migrations/20260607150733_AddTrainerCapacityAndNotes.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CoachOS.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTrainerCapacityAndNotes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Notes",
+                table: "OrganizationMemberships",
+                type: "character varying(1000)",
+                maxLength: 1000,
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "WeeklyCapacityHours",
+                table: "OrganizationMemberships",
+                type: "integer",
+                nullable: false,
+                defaultValue: 16);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Notes",
+                table: "OrganizationMemberships");
+
+            migrationBuilder.DropColumn(
+                name: "WeeklyCapacityHours",
+                table: "OrganizationMemberships");
+        }
+    }
+}

--- a/backend/CoachOS.Infrastructure/Persistence/Configurations/OrganizationMembershipConfiguration.cs
+++ b/backend/CoachOS.Infrastructure/Persistence/Configurations/OrganizationMembershipConfiguration.cs
@@ -14,6 +14,8 @@ public class OrganizationMembershipConfiguration : IEntityTypeConfiguration<Orga
         builder.Property(m => m.OrganizationId).IsRequired();
         builder.Property(m => m.Role).IsRequired();
         builder.Property(m => m.IsActive).IsRequired();
+        builder.Property(m => m.WeeklyCapacityHours).IsRequired().HasDefaultValue(16);
+        builder.Property(m => m.Notes).HasMaxLength(1000);
         builder.Property(m => m.JoinedAt).IsRequired();
 
         builder.HasOne(m => m.Organization)

--- a/backend/CoachOS.Tests/Validators/UpdateTrainerRequestValidatorTests.cs
+++ b/backend/CoachOS.Tests/Validators/UpdateTrainerRequestValidatorTests.cs
@@ -1,0 +1,81 @@
+using CoachOS.Application.Trainers.DTOs;
+using CoachOS.Application.Trainers.Validators;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace CoachOS.Tests.Validators;
+
+[TestFixture]
+public class UpdateTrainerRequestValidatorTests
+{
+    private UpdateTrainerRequestValidator _validator = null!;
+
+    [SetUp]
+    public void SetUp() => _validator = new UpdateTrainerRequestValidator();
+
+    private static UpdateTrainerRequest Valid() => new()
+    {
+        FirstName = "Jan",
+        LastName = "Janssen",
+        WeeklyCapacityHours = 20,
+        Notes = "Werkt alleen woensdag"
+    };
+
+    [Test]
+    public void Valid_request_passes()
+    {
+        var result = _validator.Validate(Valid());
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Test]
+    public void Null_notes_passes()
+    {
+        var result = _validator.Validate(Valid() with { Notes = null });
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Test]
+    public void Empty_first_or_last_name_fails()
+    {
+        var result = _validator.Validate(Valid() with { FirstName = "", LastName = "" });
+        result.IsValid.Should().BeFalse();
+        result.Errors.Select(e => e.PropertyName).Should().Contain(new[]
+        {
+            nameof(UpdateTrainerRequest.FirstName),
+            nameof(UpdateTrainerRequest.LastName)
+        });
+    }
+
+    [Test]
+    public void Capacity_below_one_fails()
+    {
+        var result = _validator.Validate(Valid() with { WeeklyCapacityHours = 0 });
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(UpdateTrainerRequest.WeeklyCapacityHours));
+    }
+
+    [Test]
+    public void Capacity_above_eighty_fails()
+    {
+        var result = _validator.Validate(Valid() with { WeeklyCapacityHours = 81 });
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(UpdateTrainerRequest.WeeklyCapacityHours));
+    }
+
+    [Test]
+    public void Html_in_name_fails()
+    {
+        var result = _validator.Validate(Valid() with { FirstName = "<script>" });
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(UpdateTrainerRequest.FirstName));
+    }
+
+    [Test]
+    public void Notes_over_1000_chars_fails()
+    {
+        var result = _validator.Validate(Valid() with { Notes = new string('a', 1001) });
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(UpdateTrainerRequest.Notes));
+    }
+}

--- a/frontend/app/(dashboard)/dashboard/trainers/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/trainers/page.tsx
@@ -12,6 +12,8 @@ import {
   Trash2,
   Mail,
   X,
+  Pencil,
+  StickyNote,
 } from "lucide-react";
 import { Mono } from "@/components/ui/mono";
 import {
@@ -603,8 +605,17 @@ export default function TrainersPage() {
                   </div>
                   <div className="flex-1 min-w-0">
                     <div className="flex justify-between items-center">
-                      <p className="text-[13.5px] font-bold text-ink m-0">
+                      <p className="text-[13.5px] font-bold text-ink m-0 flex items-center gap-1.5">
                         {tr.firstName} {tr.lastName}
+                        {tr.notes && tr.notes.trim() && (
+                          <StickyNote
+                            size={12}
+                            className="text-amber-500 shrink-0"
+                            aria-label={t("notesIndicator")}
+                          >
+                            <title>{tr.notes}</title>
+                          </StickyNote>
+                        )}
                       </p>
                       {isSelfAdmin ? (
                         <span className="text-[10px] px-2 py-0.5 rounded-full bg-tennis-lime/30 text-tennis-green font-semibold">
@@ -670,6 +681,13 @@ export default function TrainersPage() {
                         ) : (
                           <>
                             <button
+                              onClick={() => setEditTrainer(tr)}
+                              title={t("edit")}
+                              className="opacity-0 group-hover:opacity-100 p-1.5 rounded text-ink-3 hover:text-tennis-green hover:bg-tennis-green/10 transition-all"
+                            >
+                              <Pencil size={14} />
+                            </button>
+                            <button
                               onClick={() => deactivateMutation.mutate(tr.id)}
                               disabled={deactivateMutation.isPending}
                               title={t("deactivate")}
@@ -698,6 +716,13 @@ export default function TrainersPage() {
                     <p className="text-[11px] text-amber-800 m-0">{t("invitePending")}</p>
                     <div className="flex items-center gap-1.5">
                       <button
+                        onClick={() => setEditTrainer(tr)}
+                        title={t("edit")}
+                        className="p-1.5 rounded text-amber-700 hover:text-tennis-green hover:bg-tennis-green/10 transition-all"
+                      >
+                        <Pencil size={14} />
+                      </button>
+                      <button
                         onClick={() => resendMutation.mutate(tr.id)}
                         disabled={resendMutation.isPending}
                         className="px-2.5 py-1 bg-white border border-amber-300 rounded text-[10.5px] text-amber-800 font-semibold disabled:opacity-50"
@@ -717,6 +742,13 @@ export default function TrainersPage() {
 
                 {isDeactivatedState && (
                   <div className="mt-3 flex gap-1 justify-end">
+                    <button
+                      onClick={() => setEditTrainer(tr)}
+                      title={t("edit")}
+                      className="p-1.5 rounded text-ink-3 hover:text-tennis-green hover:bg-tennis-green/10 transition-all"
+                    >
+                      <Pencil size={14} />
+                    </button>
                     <button
                       onClick={() => handleRemoveClick(tr)}
                       title={t("remove")}

--- a/frontend/app/(dashboard)/dashboard/trainers/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/trainers/page.tsx
@@ -17,12 +17,14 @@ import { Mono } from "@/components/ui/mono";
 import {
   getTrainers,
   inviteTrainer,
+  updateTrainer,
   deactivateTrainer,
   reassignTrainerSeries,
   removeTrainer,
   resendTrainerInvite,
   TrainerDto,
 } from "@/lib/api/trainers";
+import { Textarea } from "@/components/ui/textarea";
 import { getAxiosErrorMessages } from "@/lib/utils/api-errors";
 import { getInitials } from "@/lib/utils/initials";
 import { getAuthUser, type AuthUser } from "@/lib/auth";
@@ -56,6 +58,19 @@ const inviteSchema = z.object({
 });
 
 type InviteFormValues = z.infer<typeof inviteSchema>;
+
+const editSchema = z.object({
+  firstName: z.string().min(1, "Voornaam is verplicht").max(100),
+  lastName: z.string().min(1, "Achternaam is verplicht").max(100),
+  weeklyCapacityHours: z
+    .number({ message: "Vul een aantal uur in" })
+    .int()
+    .min(1, "Minimaal 1 uur")
+    .max(80, "Maximaal 80 uur"),
+  notes: z.string().max(1000, "Maximaal 1000 karakters").optional(),
+});
+
+type EditFormValues = z.infer<typeof editSchema>;
 
 // ─── Capacity label helper ────────────────────────────────────────────────────
 
@@ -311,6 +326,137 @@ function InviteForm({ onClose }: { onClose: () => void }) {
   );
 }
 
+// ─── Edit dialog ───────────────────────────────────────────────────────────────
+
+function EditTrainerDialog({
+  trainer,
+  onClose,
+}: {
+  trainer: TrainerDto;
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [apiErrors, setApiErrors] = useState<string[]>([]);
+  const t = useTranslations("trainers");
+  const tCommon = useTranslations("common");
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<EditFormValues>({
+    resolver: zodResolver(editSchema),
+    defaultValues: {
+      firstName: trainer.firstName,
+      lastName: trainer.lastName,
+      weeklyCapacityHours: trainer.weeklyCapacityHours,
+      notes: trainer.notes ?? "",
+    },
+  });
+
+  const mutation = useMutation({
+    mutationFn: (values: EditFormValues) =>
+      updateTrainer(trainer.id, {
+        firstName: values.firstName,
+        lastName: values.lastName,
+        weeklyCapacityHours: values.weeklyCapacityHours,
+        notes: values.notes && values.notes.trim() ? values.notes : null,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["trainers"] });
+      onClose();
+    },
+    onError: (err) => {
+      setApiErrors(getAxiosErrorMessages(err, t("editError")));
+    },
+  });
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t("editTitle")}</DialogTitle>
+        </DialogHeader>
+
+        <form
+          onSubmit={handleSubmit((d) => {
+            setApiErrors([]);
+            mutation.mutate(d);
+          })}
+          className="space-y-4"
+        >
+          {apiErrors.length > 0 && (
+            <div className="bg-red-50 border border-red-100 rounded-lg px-4 py-3 text-sm text-red-600">
+              {apiErrors.map((e, i) => <p key={i}>{e}</p>)}
+            </div>
+          )}
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1.5">
+                {t("firstName")} <span className="text-red-400">*</span>
+              </label>
+              <input {...register("firstName")} type="text" className={inputClass} />
+              <FieldError message={errors.firstName?.message} />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1.5">
+                {t("lastName")} <span className="text-red-400">*</span>
+              </label>
+              <input {...register("lastName")} type="text" className={inputClass} />
+              <FieldError message={errors.lastName?.message} />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1.5">
+              {t("weeklyCapacity")} <span className="text-red-400">*</span>
+            </label>
+            <input
+              {...register("weeklyCapacityHours", { valueAsNumber: true })}
+              type="number"
+              min={1}
+              max={80}
+              className={inputClass}
+            />
+            <p className="text-[11px] text-gray-400 mt-1">{t("weeklyCapacityHint")}</p>
+            <FieldError message={errors.weeklyCapacityHours?.message} />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1.5">
+              {t("notes")}
+            </label>
+            <Textarea
+              {...register("notes")}
+              rows={3}
+              placeholder={t("notesPlaceholder")}
+            />
+            <FieldError message={errors.notes?.message} />
+          </div>
+
+          <div className="flex items-center gap-3 pt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 px-4 py-2.5 border border-gray-200 text-sm font-medium text-gray-600 rounded-lg hover:bg-gray-50 transition-colors"
+            >
+              {tCommon("cancel")}
+            </button>
+            <button
+              type="submit"
+              disabled={mutation.isPending}
+              className="flex-1 px-4 py-2.5 bg-tennis-green text-white text-sm font-semibold rounded-lg hover:bg-tennis-green/90 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+            >
+              {mutation.isPending ? t("saving") : t("save")}
+            </button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 type RemoveDialogState =
@@ -321,6 +467,7 @@ type RemoveDialogState =
 export default function TrainersPage() {
   const [showInviteForm, setShowInviteForm] = useState(false);
   const [removeDialog, setRemoveDialog] = useState<RemoveDialogState>({ type: "none" });
+  const [editTrainer, setEditTrainer] = useState<TrainerDto | null>(null);
   const [user, setUser] = useState<AuthUser | null>(null);
   const queryClient = useQueryClient();
   const t = useTranslations("trainers");
@@ -606,6 +753,12 @@ export default function TrainersPage() {
             })
           }
           isProcessing={reassignAndRemoveMutation.isPending}
+        />
+      )}
+      {editTrainer && (
+        <EditTrainerDialog
+          trainer={editTrainer}
+          onClose={() => setEditTrainer(null)}
         />
       )}
     </>

--- a/frontend/app/(dashboard)/dashboard/trainers/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/trainers/page.tsx
@@ -419,6 +419,7 @@ function EditTrainerDialog({
               type="number"
               min={1}
               max={80}
+              step={1}
               className={inputClass}
             />
             <p className="text-[11px] text-gray-400 mt-1">{t("weeklyCapacityHint")}</p>

--- a/frontend/lib/api/trainers.ts
+++ b/frontend/lib/api/trainers.ts
@@ -11,6 +11,7 @@ export interface TrainerDto {
   lessonSeriesCount: number;
   currentWeekHoursBooked: number;
   weeklyCapacityHours: number;
+  notes: string | null;
   createdAt: string;
 }
 
@@ -18,6 +19,13 @@ export interface InviteTrainerRequest {
   firstName: string;
   lastName: string;
   email: string;
+}
+
+export interface UpdateTrainerRequest {
+  firstName: string;
+  lastName: string;
+  weeklyCapacityHours: number;
+  notes: string | null;
 }
 
 export interface AcceptInviteRequest {
@@ -37,6 +45,13 @@ export function isAssignableTrainer(t: TrainerDto): boolean {
 export async function inviteTrainer(req: InviteTrainerRequest): Promise<string> {
   const { data } = await apiClient.post<string>("/trainers/invite", req);
   return data;
+}
+
+export async function updateTrainer(
+  id: string,
+  req: UpdateTrainerRequest,
+): Promise<void> {
+  await apiClient.put(`/trainers/${id}`, req);
 }
 
 export async function acceptInvite(req: AcceptInviteRequest): Promise<AuthResponse> {

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -490,7 +490,17 @@
     "removing": "Verwijderen...",
     "reassignAndRemove": "Toewijzen & verwijderen",
     "processing": "Bezig...",
-    "status": "Status"
+    "status": "Status",
+    "edit": "Bewerken",
+    "editTitle": "Trainer bewerken",
+    "weeklyCapacity": "Weekcapaciteit (uur)",
+    "weeklyCapacityHint": "Maximaal aantal lesuren per week voor deze club (1–80).",
+    "notes": "Interne notitie",
+    "notesPlaceholder": "Alleen zichtbaar voor het beheer — bijv. beschikbaarheid of afspraken.",
+    "notesIndicator": "Heeft een interne notitie",
+    "save": "Opslaan",
+    "saving": "Opslaan...",
+    "editError": "Wijziging kon niet worden opgeslagen"
   },
   "auth": {
     "login": "Inloggen",


### PR DESCRIPTION
## Samenvatting
- Admin kan per trainer de **weekcapaciteit** (1–80u, per club), **naam** (globaal) en een **interne notitie** (per club) bewerken via een dialoog op `/dashboard/trainers`
- Nieuw: `PUT /trainers/{id}` + `ITrainerService.UpdateAsync`; `GetTrainersAsync` geeft nu de echte capaciteit + notitie; velden op `OrganizationMembership` + migratie `AddTrainerCapacityAndNotes`
- Weekbelasting-balk gebruikt voortaan de ingestelde capaciteit; notitie-indicator (icoon + tooltip) op de kaart
- Buiten scope (bewust): geen planning-blokkade bij overcapaciteit, geen e-mail/telefoon bewerken

## Test Plan
- [x] `dotnet test` 213/213 (incl. 7 nieuwe validator-tests, TDD)
- [x] Reset + seed E2E groen (migratie past toe op lege DB)
- [x] API end-to-end (curl): PUT 204 + persistentie; 400 bij ongeldige capaciteit/naam
- [x] Handmatige UI-check (Playwright): bewerken, opslaan, notitie-indicator, 1–80 validatie

🤖 Generated with [Claude Code](https://claude.com/claude-code)