### PR TITLE
chore(infra): align VPS instance type with PRO2-XXS (drift fix)

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -117,13 +117,17 @@ certbot renew --dry-run
 
 | Item | Cost |
 |---|---|
-| VPS (Stardust S1, 1 vCPU / 1 GB RAM) | ~€4 |
+| VPS (PRO2-XXS, 2 vCPU / 8 GB RAM) | ~€41 |
 | Reserved IP | ~€1 |
 | Managed Postgres (DB-DEV-S, 10 GB) | ~€12 |
 | Container Registry (storage-billed) | ~€0–2 |
 | Transactional Email (~1k mails/mo) | ~€0–1 |
 | Secret Manager (~10 secrets) | ~€0 |
 | Object Storage (TF state, <1 GB) | ~€0 |
-| **Total** | **~€18–20** |
+| Domain (coach-os.be, ~€7/yr) | ~€0.60 |
+| **Total** | **~€55** |
 
-Bump VPS to DEV1-S (~€11) once you're past ~10 active organizations.
+The VPS was bumped from STARDUST1-S (1 GB RAM, ~€4) to PRO2-XXS (8 GB) because
+1 GB couldn't hold all 6 containers (.NET API + 2x Next.js SSR + nginx + dozzle).
+Next scaling concern is Postgres: `DB-DEV-S` is single-node — enable HA
+(`is_ha_cluster = true`, ~2x DB cost) before onboarding paying customers.

--- a/infrastructure/terraform/terraform.tfvars.example
+++ b/infrastructure/terraform/terraform.tfvars.example
@@ -12,8 +12,9 @@ domain_name = "coach-os.be"
 # Then paste the contents of ~/.ssh/coach-os-gha.pub here:
 ssh_public_key = "ssh-ed25519 AAAA... gha-deploy@coach-os"
 
-# Cheapest viable defaults; bump these only if metrics demand it.
-vps_instance_type = "STARDUST1-S"
+# Current prod sizing. PRO2-XXS (2 vCPU / 8 GB) — STARDUST1-S (1 GB) ran out
+# of RAM with all 6 containers. Drop to DEV1-S only if the workload shrinks.
+vps_instance_type = "PRO2-XXS"
 vps_image         = "ubuntu_jammy"
 db_node_type      = "DB-DEV-S"
 db_volume_size_gb = 10

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -32,9 +32,9 @@ variable "ssh_public_key" {
 }
 
 variable "vps_instance_type" {
-  description = "Scaleway instance commercial type. Stardust S1 (STARDUST1-S) is cheapest (~€4/mo, 1 vCPU, 1 GB); upgrade to DEV1-S/PRO2-XXS if needed."
+  description = "Scaleway instance commercial type. PRO2-XXS (2 vCPU, 8 GB, ~€41/mo) is the current prod size — STARDUST1-S (1 GB) ran out of RAM with all 6 containers. Drop to DEV1-S (2 vCPU, 2 GB, ~€7/mo) only if the workload shrinks."
   type        = string
-  default     = "STARDUST1-S"
+  default     = "PRO2-XXS"
 }
 
 variable "vps_image" {


### PR DESCRIPTION
## Wat

De productie-VPS is handmatig via de Scaleway UI geresized van `STARDUST1-S`
(1 vCPU / 1 GB) naar `PRO2-XXS` (2 vCPU / 8 GB) — 1 GB RAM was te krap voor
alle 6 containers (.NET API + 2× Next.js SSR + nginx + dozzle). Deze PR trekt
de Terraform-config gelijk met die realiteit (drift-fix).

## Waarom dit nodig is

De `terraform.yml` workflow doet `tofu plan + auto-apply` bij elke push naar
`infrastructure/terraform/**`. CI levert `vps_instance_type` **niet** via een
`TF_VAR_`, dus het valt terug op de **default in `variables.tf`** — die nog op
`STARDUST1-S` stond. Een apply zou de instance dus hebben **teruggedowngraded**
→ downtime + mogelijk verlies van het boot-volume (incl. de DataProtection
keystore → elke club zou Mollie opnieuw moeten koppelen).

## Wijzigingen

- `terraform/variables.tf` — default `vps_instance_type` → `PRO2-XXS` (dit is
  wat CI daadwerkelijk gebruikt)
- `terraform/terraform.tfvars.example` — template bijgewerkt naar `PRO2-XXS`
- `infrastructure/README.md` — kostenraming → ~€55/mo, domein-regel +
  DB-HA scaling-noot toegevoegd

`terraform.tfvars` zelf is en blijft gitignored — niet in deze PR.

## Test plan

- [ ] `cd infrastructure/terraform && tofu plan` → **"No changes"** (bewijst dat
  de drift weg is en auto-apply niets meer wil wijzigen)
