### PR TITLE
chore(infra): replace deprecated RDB endpoint_ip/endpoint_port

### DIFF
--- a/infrastructure/terraform/outputs.tf
+++ b/infrastructure/terraform/outputs.tf
@@ -18,13 +18,13 @@ output "registry_endpoint" {
 
 output "db_host" {
   description = "Managed Postgres host."
-  value       = scaleway_rdb_instance.coach_os.endpoint_ip
+  value       = scaleway_rdb_instance.coach_os.load_balancer.0.ip
   sensitive   = true
 }
 
 output "db_port" {
   description = "Managed Postgres port."
-  value       = scaleway_rdb_instance.coach_os.endpoint_port
+  value       = scaleway_rdb_instance.coach_os.load_balancer.0.port
 }
 
 output "db_name" {

--- a/infrastructure/terraform/secrets.tf
+++ b/infrastructure/terraform/secrets.tf
@@ -13,8 +13,8 @@ resource "random_password" "jwt_key" {
 
 locals {
   db_connection_string = join(";", [
-    "Host=${scaleway_rdb_instance.coach_os.endpoint_ip}",
-    "Port=${scaleway_rdb_instance.coach_os.endpoint_port}",
+    "Host=${scaleway_rdb_instance.coach_os.load_balancer.0.ip}",
+    "Port=${scaleway_rdb_instance.coach_os.load_balancer.0.port}",
     "Database=${scaleway_rdb_database.coach_os.name}",
     "Username=${scaleway_rdb_instance.coach_os.user_name}",
     "Password=${random_password.db.result}",


### PR DESCRIPTION
## Wat

De Scaleway-provider markeert `scaleway_rdb_instance.*.endpoint_ip` en
`.endpoint_port` als **deprecated** ("Please use the private_network or the
load_balancer attribute"). Deze PR vervangt ze door de aanbevolen
`load_balancer.0.ip` / `load_balancer.0.port` — dezelfde publieke endpoint,
andere attribuutnaam.

## Waarom

`tofu plan` gaf 8 deprecation-warnings. Werkt nu nog, maar `endpoint_ip` kan
in een volgende provider-upgrade verdwijnen (we zitten op `scaleway` 2.72.0).
Nu opruimen voorkomt een verrassing bij de volgende `tofu init -upgrade`.

## Wijzigingen

- `terraform/outputs.tf` — `db_host` / `db_port` outputs
- `terraform/secrets.tf` — `Host=` / `Port=` in `local.db_connection_string`
  (de `DatabaseSettings__ConnectionString` secret)

Vervanging geverifieerd tegen de officiële provider-docs:
`endpoint_ip` → `load_balancer.0.ip`, `endpoint_port` → `load_balancer.0.port`.

## ⚠️ Verplichte check vóór merge

`load_balancer.0.ip` hoort dezelfde waarde te geven als het oude `endpoint_ip`,
dus de connection-string-secret mag **niet** veranderen. Bevestig dit:

```
cd infrastructure/terraform && tofu plan
```

- ✅ **"No changes"** → veilig te mergen, geen warnings meer.
- ❌ Een diff op `scaleway_secret_version.app["DatabaseSettings__ConnectionString"]`
  of op `db_host` / `db_port` → de endpoint-waarde wijkt af. **Niet mergen** —
  dat zou een nieuwe secret-versie schrijven en de API laten herstarten met een
  gewijzigde DB-host. Eerst onderzoeken.

## Test plan

- [ ] `tofu plan` → "No changes" én geen deprecation-warnings meer
