### PR TITLE
Trainerbeschikbaarheid (admin-invoer)

### DIFF
--- a/backend/CoachOS.API/Endpoints/TrainerAvailabilities/CreateTrainerAvailabilityEndpoint.cs
+++ b/backend/CoachOS.API/Endpoints/TrainerAvailabilities/CreateTrainerAvailabilityEndpoint.cs
@@ -1,0 +1,24 @@
+using CoachOS.API.Extensions;
+using CoachOS.API.Filters;
+using CoachOS.Application.TrainerAvailabilities;
+using CoachOS.Application.TrainerAvailabilities.DTOs;
+using CoachOS.Domain.Models;
+
+namespace CoachOS.API.Endpoints.TrainerAvailabilities;
+
+public class CreateTrainerAvailabilityEndpoint : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPost("/trainer-availabilities", async (CreateTrainerAvailabilityRequest request, ITrainerAvailabilityService service, HttpContext ctx, CancellationToken ct) =>
+        {
+            Result<Guid> result = await service.CreateAsync(ctx.GetOrganizationId(), request, ct);
+            return result.IsSuccess
+                ? Results.Created($"/api/trainer-availabilities/{result.Value}", result.Value)
+                : result.ToErrorResult();
+        })
+        .RequireAuthorization()
+        .AddEndpointFilter<ValidationFilter<CreateTrainerAvailabilityRequest>>()
+        .WithTags("TrainerAvailabilities");
+    }
+}

--- a/backend/CoachOS.API/Endpoints/TrainerAvailabilities/DeleteTrainerAvailabilityEndpoint.cs
+++ b/backend/CoachOS.API/Endpoints/TrainerAvailabilities/DeleteTrainerAvailabilityEndpoint.cs
@@ -1,0 +1,19 @@
+using CoachOS.API.Extensions;
+using CoachOS.Application.TrainerAvailabilities;
+using CoachOS.Domain.Models;
+
+namespace CoachOS.API.Endpoints.TrainerAvailabilities;
+
+public class DeleteTrainerAvailabilityEndpoint : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapDelete("/trainer-availabilities/{id:guid}", async (Guid id, ITrainerAvailabilityService service, HttpContext ctx, CancellationToken ct) =>
+        {
+            Result result = await service.DeleteAsync(id, ctx.GetOrganizationId(), ct);
+            return result.IsSuccess ? Results.NoContent() : result.ToErrorResult();
+        })
+        .RequireAuthorization()
+        .WithTags("TrainerAvailabilities");
+    }
+}

--- a/backend/CoachOS.API/Endpoints/TrainerAvailabilities/GetTrainerAvailabilitiesEndpoint.cs
+++ b/backend/CoachOS.API/Endpoints/TrainerAvailabilities/GetTrainerAvailabilitiesEndpoint.cs
@@ -1,0 +1,20 @@
+using CoachOS.API.Extensions;
+using CoachOS.Application.TrainerAvailabilities;
+using CoachOS.Application.TrainerAvailabilities.DTOs;
+using CoachOS.Domain.Models;
+
+namespace CoachOS.API.Endpoints.TrainerAvailabilities;
+
+public class GetTrainerAvailabilitiesEndpoint : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/trainer-availabilities", async (ITrainerAvailabilityService service, HttpContext ctx, CancellationToken ct) =>
+        {
+            Result<List<TrainerAvailabilityDto>> result = await service.GetAllAsync(ctx.GetOrganizationId(), ct);
+            return result.IsSuccess ? Results.Ok(result.Value) : result.ToErrorResult();
+        })
+        .RequireAuthorization()
+        .WithTags("TrainerAvailabilities");
+    }
+}

--- a/backend/CoachOS.Application/DependencyInjection.cs
+++ b/backend/CoachOS.Application/DependencyInjection.cs
@@ -14,6 +14,7 @@ using CoachOS.Application.StandaloneLessons;
 using CoachOS.Application.StudentConfirmation;
 using CoachOS.Application.Students;
 using CoachOS.Application.TennisClubs;
+using CoachOS.Application.TrainerAvailabilities;
 using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -29,6 +30,7 @@ public static class DependencyInjection
         services.AddScoped<IDashboardService, DashboardService>();
         services.AddScoped<ILessonSerieService, LessonSerieService>();
         services.AddScoped<ITennisClubService, TennisClubService>();
+        services.AddScoped<ITrainerAvailabilityService, TrainerAvailabilityService>();
         services.AddScoped<IEnrollmentService, EnrollmentService>();
         services.AddScoped<IPlanningService, PlanningService>();
         services.AddScoped<IAssignmentService, AssignmentService>();

--- a/backend/CoachOS.Application/Mappings/ApplicationMapper.cs
+++ b/backend/CoachOS.Application/Mappings/ApplicationMapper.cs
@@ -189,7 +189,7 @@ public partial class ApplicationMapper
             availability.Id,
             availability.TrainerId,
             availability.TennisClubId,
-            availability.TennisClub?.Name ?? string.Empty,
+            availability.TennisClub?.Name,
             availability.DayOfWeek,
             availability.StartTime.ToString("HH\\:mm"),
             availability.EndTime.ToString("HH\\:mm"));

--- a/backend/CoachOS.Application/Mappings/ApplicationMapper.cs
+++ b/backend/CoachOS.Application/Mappings/ApplicationMapper.cs
@@ -3,6 +3,7 @@ using CoachOS.Application.LessonSerie.DTOs;
 using CoachOS.Application.OrganizationSettings.DTOs;
 using CoachOS.Application.StandaloneLessons.DTOs;
 using CoachOS.Application.TennisClubs.DTOs;
+using CoachOS.Application.TrainerAvailabilities.DTOs;
 using CoachOS.Domain.Entities;
 using CoachOS.Domain.Enums;
 using Riok.Mapperly.Abstractions;
@@ -169,4 +170,27 @@ public partial class ApplicationMapper
             RespondedAt = invitation.RespondedAt,
         };
     }
+
+    public TrainerAvailability ToTrainerAvailability(CreateTrainerAvailabilityRequest request, Guid organizationId)
+        => new()
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = organizationId,
+            TrainerId = request.TrainerId,
+            TennisClubId = request.TennisClubId,
+            DayOfWeek = request.DayOfWeek,
+            StartTime = TimeOnly.ParseExact(request.StartTime, "HH:mm"),
+            EndTime = TimeOnly.ParseExact(request.EndTime, "HH:mm"),
+            IsActive = true,
+        };
+
+    public TrainerAvailabilityDto ToTrainerAvailabilityDto(TrainerAvailability availability)
+        => new(
+            availability.Id,
+            availability.TrainerId,
+            availability.TennisClubId,
+            availability.TennisClub?.Name ?? string.Empty,
+            availability.DayOfWeek,
+            availability.StartTime.ToString("HH\\:mm"),
+            availability.EndTime.ToString("HH\\:mm"));
 }

--- a/backend/CoachOS.Application/TrainerAvailabilities/DTOs/CreateTrainerAvailabilityRequest.cs
+++ b/backend/CoachOS.Application/TrainerAvailabilities/DTOs/CreateTrainerAvailabilityRequest.cs
@@ -1,9 +1,12 @@
 namespace CoachOS.Application.TrainerAvailabilities.DTOs;
 
-/// <summary>Tijden in "HH:mm" formaat (24u).</summary>
+/// <summary>
+/// Tijden in "HH:mm" formaat (24u). TennisClubId is optioneel - null betekent
+/// "beschikbaar bij eender welke club".
+/// </summary>
 public record CreateTrainerAvailabilityRequest(
     Guid TrainerId,
-    Guid TennisClubId,
+    Guid? TennisClubId,
     int DayOfWeek,
     string StartTime,
     string EndTime);

--- a/backend/CoachOS.Application/TrainerAvailabilities/DTOs/CreateTrainerAvailabilityRequest.cs
+++ b/backend/CoachOS.Application/TrainerAvailabilities/DTOs/CreateTrainerAvailabilityRequest.cs
@@ -1,0 +1,9 @@
+namespace CoachOS.Application.TrainerAvailabilities.DTOs;
+
+/// <summary>Tijden in "HH:mm" formaat (24u).</summary>
+public record CreateTrainerAvailabilityRequest(
+    Guid TrainerId,
+    Guid TennisClubId,
+    int DayOfWeek,
+    string StartTime,
+    string EndTime);

--- a/backend/CoachOS.Application/TrainerAvailabilities/DTOs/TrainerAvailabilityDto.cs
+++ b/backend/CoachOS.Application/TrainerAvailabilities/DTOs/TrainerAvailabilityDto.cs
@@ -1,0 +1,10 @@
+namespace CoachOS.Application.TrainerAvailabilities.DTOs;
+
+public record TrainerAvailabilityDto(
+    Guid Id,
+    Guid TrainerId,
+    Guid TennisClubId,
+    string TennisClubName,
+    int DayOfWeek,
+    string StartTime,
+    string EndTime);

--- a/backend/CoachOS.Application/TrainerAvailabilities/DTOs/TrainerAvailabilityDto.cs
+++ b/backend/CoachOS.Application/TrainerAvailabilities/DTOs/TrainerAvailabilityDto.cs
@@ -3,8 +3,8 @@ namespace CoachOS.Application.TrainerAvailabilities.DTOs;
 public record TrainerAvailabilityDto(
     Guid Id,
     Guid TrainerId,
-    Guid TennisClubId,
-    string TennisClubName,
+    Guid? TennisClubId,
+    string? TennisClubName,
     int DayOfWeek,
     string StartTime,
     string EndTime);

--- a/backend/CoachOS.Application/TrainerAvailabilities/ITrainerAvailabilityService.cs
+++ b/backend/CoachOS.Application/TrainerAvailabilities/ITrainerAvailabilityService.cs
@@ -1,0 +1,11 @@
+using CoachOS.Application.TrainerAvailabilities.DTOs;
+using CoachOS.Domain.Models;
+
+namespace CoachOS.Application.TrainerAvailabilities;
+
+public interface ITrainerAvailabilityService
+{
+    Task<Result<List<TrainerAvailabilityDto>>> GetAllAsync(Guid organizationId, CancellationToken ct = default);
+    Task<Result<Guid>> CreateAsync(Guid organizationId, CreateTrainerAvailabilityRequest request, CancellationToken ct = default);
+    Task<Result> DeleteAsync(Guid id, Guid organizationId, CancellationToken ct = default);
+}

--- a/backend/CoachOS.Application/TrainerAvailabilities/TrainerAvailabilityService.cs
+++ b/backend/CoachOS.Application/TrainerAvailabilities/TrainerAvailabilityService.cs
@@ -20,9 +20,13 @@ public class TrainerAvailabilityService(
 
     public async Task<Result<Guid>> CreateAsync(Guid organizationId, CreateTrainerAvailabilityRequest request, CancellationToken ct = default)
     {
-        bool clubExists = await clubRepo.ExistsAsync(request.TennisClubId, organizationId, ct);
-        if (!clubExists)
-            return Result<Guid>.Fail(new Error(ErrorCodes.NotFound, "Club niet gevonden"));
+        // Club is optioneel (null = eender welke club). Alleen valideren wanneer opgegeven.
+        if (request.TennisClubId.HasValue)
+        {
+            bool clubExists = await clubRepo.ExistsAsync(request.TennisClubId.Value, organizationId, ct);
+            if (!clubExists)
+                return Result<Guid>.Fail(new Error(ErrorCodes.NotFound, "Club niet gevonden"));
+        }
 
         bool isActiveTrainer = await userLookup.IsActiveTrainerAsync(request.TrainerId, organizationId, ct);
         if (!isActiveTrainer)

--- a/backend/CoachOS.Application/TrainerAvailabilities/TrainerAvailabilityService.cs
+++ b/backend/CoachOS.Application/TrainerAvailabilities/TrainerAvailabilityService.cs
@@ -1,0 +1,54 @@
+using CoachOS.Application.Mappings;
+using CoachOS.Application.TrainerAvailabilities.DTOs;
+using CoachOS.Domain.Entities;
+using CoachOS.Domain.Interfaces;
+using CoachOS.Domain.Models;
+
+namespace CoachOS.Application.TrainerAvailabilities;
+
+public class TrainerAvailabilityService(
+    ITrainerAvailabilityRepository repo,
+    ITennisClubRepository clubRepo,
+    IUserLookupService userLookup,
+    ApplicationMapper mapper) : ITrainerAvailabilityService
+{
+    public async Task<Result<List<TrainerAvailabilityDto>>> GetAllAsync(Guid organizationId, CancellationToken ct = default)
+    {
+        IReadOnlyList<TrainerAvailability> availabilities = await repo.GetByOrganizationAsync(organizationId, ct);
+        return Result<List<TrainerAvailabilityDto>>.Ok(availabilities.Select(mapper.ToTrainerAvailabilityDto).ToList());
+    }
+
+    public async Task<Result<Guid>> CreateAsync(Guid organizationId, CreateTrainerAvailabilityRequest request, CancellationToken ct = default)
+    {
+        bool clubExists = await clubRepo.ExistsAsync(request.TennisClubId, organizationId, ct);
+        if (!clubExists)
+            return Result<Guid>.Fail(new Error(ErrorCodes.NotFound, "Club niet gevonden"));
+
+        bool isActiveTrainer = await userLookup.IsActiveTrainerAsync(request.TrainerId, organizationId, ct);
+        if (!isActiveTrainer)
+            return Result<Guid>.Fail(new Error(ErrorCodes.NotFound, "Trainer niet gevonden"));
+
+        TimeOnly startTime = TimeOnly.ParseExact(request.StartTime, "HH:mm");
+        TimeOnly endTime = TimeOnly.ParseExact(request.EndTime, "HH:mm");
+
+        bool overlaps = await repo.HasOverlapAsync(request.TrainerId, organizationId, request.DayOfWeek, startTime, endTime, ct);
+        if (overlaps)
+            return Result<Guid>.Fail(new Error(ErrorCodes.Conflict, "Deze trainer heeft op deze dag al een beschikbaarheid die overlapt"));
+
+        TrainerAvailability availability = mapper.ToTrainerAvailability(request, organizationId);
+        await repo.AddAsync(availability, ct);
+        await repo.SaveChangesAsync(ct);
+        return Result<Guid>.Ok(availability.Id);
+    }
+
+    public async Task<Result> DeleteAsync(Guid id, Guid organizationId, CancellationToken ct = default)
+    {
+        TrainerAvailability? availability = await repo.GetByIdAsync(id, organizationId, ct);
+        if (availability is null)
+            return Result.Fail(new Error(ErrorCodes.NotFound, "Beschikbaarheid niet gevonden"));
+
+        availability.IsActive = false;
+        await repo.SaveChangesAsync(ct);
+        return Result.Ok();
+    }
+}

--- a/backend/CoachOS.Application/TrainerAvailabilities/Validators/CreateTrainerAvailabilityRequestValidator.cs
+++ b/backend/CoachOS.Application/TrainerAvailabilities/Validators/CreateTrainerAvailabilityRequestValidator.cs
@@ -13,8 +13,11 @@ public class CreateTrainerAvailabilityRequestValidator : AbstractValidator<Creat
         RuleFor(x => x.TrainerId)
             .NotEmpty().WithMessage("Trainer is verplicht");
 
+        // TennisClubId is optioneel: null = beschikbaar bij eender welke club.
+        // Als er wel een waarde wordt meegegeven mag die niet Guid.Empty zijn.
         RuleFor(x => x.TennisClubId)
-            .NotEmpty().WithMessage("Club is verplicht");
+            .NotEqual(Guid.Empty).WithMessage("Ongeldige club")
+            .When(x => x.TennisClubId.HasValue);
 
         RuleFor(x => x.DayOfWeek)
             .InclusiveBetween(0, 6).WithMessage("Ongeldige weekdag");

--- a/backend/CoachOS.Application/TrainerAvailabilities/Validators/CreateTrainerAvailabilityRequestValidator.cs
+++ b/backend/CoachOS.Application/TrainerAvailabilities/Validators/CreateTrainerAvailabilityRequestValidator.cs
@@ -1,0 +1,34 @@
+using System.Text.RegularExpressions;
+using CoachOS.Application.TrainerAvailabilities.DTOs;
+using FluentValidation;
+
+namespace CoachOS.Application.TrainerAvailabilities.Validators;
+
+public class CreateTrainerAvailabilityRequestValidator : AbstractValidator<CreateTrainerAvailabilityRequest>
+{
+    private static readonly Regex TimePattern = new(@"^([01]\d|2[0-3]):[0-5]\d$", RegexOptions.Compiled);
+
+    public CreateTrainerAvailabilityRequestValidator()
+    {
+        RuleFor(x => x.TrainerId)
+            .NotEmpty().WithMessage("Trainer is verplicht");
+
+        RuleFor(x => x.TennisClubId)
+            .NotEmpty().WithMessage("Club is verplicht");
+
+        RuleFor(x => x.DayOfWeek)
+            .InclusiveBetween(0, 6).WithMessage("Ongeldige weekdag");
+
+        RuleFor(x => x.StartTime)
+            .Must(t => t is not null && TimePattern.IsMatch(t)).WithMessage("Ongeldige starttijd (HH:mm)");
+
+        RuleFor(x => x.EndTime)
+            .Must(t => t is not null && TimePattern.IsMatch(t)).WithMessage("Ongeldige eindtijd (HH:mm)");
+
+        RuleFor(x => x)
+            .Must(x => string.Compare(x.EndTime, x.StartTime, StringComparison.Ordinal) > 0)
+            .WithMessage("Eindtijd moet na starttijd zijn")
+            .When(x => x.StartTime is not null && x.EndTime is not null
+                && TimePattern.IsMatch(x.StartTime) && TimePattern.IsMatch(x.EndTime));
+    }
+}

--- a/backend/CoachOS.Domain/Entities/TrainerAvailability.cs
+++ b/backend/CoachOS.Domain/Entities/TrainerAvailability.cs
@@ -1,0 +1,34 @@
+using CoachOS.Domain.Common;
+
+namespace CoachOS.Domain.Entities;
+
+/// <summary>
+/// Vaste beschikbaarheid van een trainer: club x weekdag x tijdvak.
+/// Door de admin vastgelegd. Gebruikt om de trainerkeuze bij reeks-setup
+/// te ondersteunen en dubbelboekingen over clubs heen te signaleren.
+/// </summary>
+public class TrainerAvailability : BaseEntity
+{
+    public Guid OrganizationId { get; set; }
+
+    /// <summary>
+    /// Plain Guid zonder FK - ApplicationUser zit in Infrastructure (Identity),
+    /// zelfde patroon als LessonSlotBase.TrainerId.
+    /// </summary>
+    public Guid TrainerId { get; set; }
+
+    public Guid TennisClubId { get; set; }
+
+    /// <summary>0 = maandag ... 6 = zondag (zelfde conventie als WeeklyTemplateEntry).</summary>
+    public int DayOfWeek { get; set; }
+
+    public TimeOnly StartTime { get; set; }
+    public TimeOnly EndTime { get; set; }
+
+    /// <summary>Soft delete - verwijderen zet IsActive op false.</summary>
+    public bool IsActive { get; set; } = true;
+
+    // Navigation properties
+    public Organization Organization { get; set; } = null!;
+    public TennisClub TennisClub { get; set; } = null!;
+}

--- a/backend/CoachOS.Domain/Entities/TrainerAvailability.cs
+++ b/backend/CoachOS.Domain/Entities/TrainerAvailability.cs
@@ -17,7 +17,11 @@ public class TrainerAvailability : BaseEntity
     /// </summary>
     public Guid TrainerId { get; set; }
 
-    public Guid TennisClubId { get; set; }
+    /// <summary>
+    /// Optioneel. Null betekent "beschikbaar bij eender welke club" - dan hoeft
+    /// de admin niet per club een aparte beschikbaarheid aan te maken.
+    /// </summary>
+    public Guid? TennisClubId { get; set; }
 
     /// <summary>0 = maandag ... 6 = zondag (zelfde conventie als WeeklyTemplateEntry).</summary>
     public int DayOfWeek { get; set; }
@@ -30,5 +34,7 @@ public class TrainerAvailability : BaseEntity
 
     // Navigation properties
     public Organization Organization { get; set; } = null!;
-    public TennisClub TennisClub { get; set; } = null!;
+
+    /// <summary>Null wanneer de beschikbaarheid voor eender welke club geldt.</summary>
+    public TennisClub? TennisClub { get; set; }
 }

--- a/backend/CoachOS.Domain/Interfaces/ITrainerAvailabilityRepository.cs
+++ b/backend/CoachOS.Domain/Interfaces/ITrainerAvailabilityRepository.cs
@@ -1,0 +1,22 @@
+using CoachOS.Domain.Entities;
+
+namespace CoachOS.Domain.Interfaces;
+
+public interface ITrainerAvailabilityRepository
+{
+    /// <summary>Alle actieve beschikbaarheden van de organisatie, incl. TennisClub navigatie.</summary>
+    Task<IReadOnlyList<TrainerAvailability>> GetByOrganizationAsync(Guid organizationId, CancellationToken ct = default);
+
+    /// <summary>Tracked fetch voor soft delete. Enkel actieve records.</summary>
+    Task<TrainerAvailability?> GetByIdAsync(Guid id, Guid organizationId, CancellationToken ct = default);
+
+    /// <summary>
+    /// True wanneer de trainer op deze weekdag al een actieve beschikbaarheid heeft
+    /// die overlapt met [startTime, endTime) - over alle clubs heen (een trainer kan
+    /// niet op twee plekken tegelijk staan).
+    /// </summary>
+    Task<bool> HasOverlapAsync(Guid trainerId, Guid organizationId, int dayOfWeek, TimeOnly startTime, TimeOnly endTime, CancellationToken ct = default);
+
+    Task AddAsync(TrainerAvailability availability, CancellationToken ct = default);
+    Task SaveChangesAsync(CancellationToken ct = default);
+}

--- a/backend/CoachOS.Infrastructure/DependencyInjection.cs
+++ b/backend/CoachOS.Infrastructure/DependencyInjection.cs
@@ -98,6 +98,7 @@ public static class DependencyInjection
         services.AddScoped<IEnrollmentFormRepository, EnrollmentFormRepository>();
         services.AddScoped<IEnrollmentGroupRepository, EnrollmentGroupRepository>();
         services.AddScoped<ITimeSlotPreferenceRepository, TimeSlotPreferenceRepository>();
+        services.AddScoped<ITrainerAvailabilityRepository, TrainerAvailabilityRepository>();
         services.AddScoped<IScheduleAssignmentRepository, ScheduleAssignmentRepository>();
         services.AddScoped<IAssignmentConfirmationTokenRepository, AssignmentConfirmationTokenRepository>();
         services.AddScoped<IPaymentRepository, PaymentRepository>();

--- a/backend/CoachOS.Infrastructure/Migrations/20260613045047_AddTrainerAvailability.Designer.cs
+++ b/backend/CoachOS.Infrastructure/Migrations/20260613045047_AddTrainerAvailability.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CoachOS.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CoachOS.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260613045047_AddTrainerAvailability")]
+    partial class AddTrainerAvailability
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/CoachOS.Infrastructure/Migrations/20260613045047_AddTrainerAvailability.cs
+++ b/backend/CoachOS.Infrastructure/Migrations/20260613045047_AddTrainerAvailability.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CoachOS.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTrainerAvailability : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TrainerAvailabilities",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    OrganizationId = table.Column<Guid>(type: "uuid", nullable: false),
+                    TrainerId = table.Column<Guid>(type: "uuid", nullable: false),
+                    TennisClubId = table.Column<Guid>(type: "uuid", nullable: false),
+                    DayOfWeek = table.Column<int>(type: "integer", nullable: false),
+                    StartTime = table.Column<TimeOnly>(type: "time without time zone", nullable: false),
+                    EndTime = table.Column<TimeOnly>(type: "time without time zone", nullable: false),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TrainerAvailabilities", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TrainerAvailabilities_Organizations_OrganizationId",
+                        column: x => x.OrganizationId,
+                        principalTable: "Organizations",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_TrainerAvailabilities_TennisClubs_TennisClubId",
+                        column: x => x.TennisClubId,
+                        principalTable: "TennisClubs",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TrainerAvailabilities_OrganizationId",
+                table: "TrainerAvailabilities",
+                column: "OrganizationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TrainerAvailabilities_TennisClubId",
+                table: "TrainerAvailabilities",
+                column: "TennisClubId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TrainerAvailabilities_TrainerId_DayOfWeek",
+                table: "TrainerAvailabilities",
+                columns: new[] { "TrainerId", "DayOfWeek" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TrainerAvailabilities");
+        }
+    }
+}

--- a/backend/CoachOS.Infrastructure/Migrations/20260613062641_MakeTrainerAvailabilityClubOptional.Designer.cs
+++ b/backend/CoachOS.Infrastructure/Migrations/20260613062641_MakeTrainerAvailabilityClubOptional.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CoachOS.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CoachOS.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260613062641_MakeTrainerAvailabilityClubOptional")]
+    partial class MakeTrainerAvailabilityClubOptional
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/CoachOS.Infrastructure/Migrations/20260613062641_MakeTrainerAvailabilityClubOptional.cs
+++ b/backend/CoachOS.Infrastructure/Migrations/20260613062641_MakeTrainerAvailabilityClubOptional.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CoachOS.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeTrainerAvailabilityClubOptional : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "TennisClubId",
+                table: "TrainerAvailabilities",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "TennisClubId",
+                table: "TrainerAvailabilities",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+        }
+    }
+}

--- a/backend/CoachOS.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/backend/CoachOS.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -46,6 +46,7 @@ public class ApplicationDbContext(
     public DbSet<OrganizationSettings> OrganizationSettings { get; set; } = null!;
     public DbSet<MollieConnection> MollieConnections { get; set; } = null!;
     public DbSet<OAuthState> OAuthStates { get; set; } = null!;
+    public DbSet<TrainerAvailability> TrainerAvailabilities { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
@@ -73,6 +74,7 @@ public class ApplicationDbContext(
         builder.ApplyConfiguration(new OrganizationSettingsConfiguration());
         builder.ApplyConfiguration(new MollieConnectionConfiguration());
         builder.ApplyConfiguration(new OAuthStateConfiguration());
+        builder.ApplyConfiguration(new TrainerAvailabilityConfiguration());
 
         ApplyTenantFilters(builder);
     }
@@ -116,6 +118,8 @@ public class ApplicationDbContext(
         builder.Entity<MollieConnection>().HasQueryFilter(e =>
             _tenant.OrganizationId == Guid.Empty || e.OrganizationId == _tenant.OrganizationId);
         builder.Entity<OAuthState>().HasQueryFilter(e =>
+            _tenant.OrganizationId == Guid.Empty || e.OrganizationId == _tenant.OrganizationId);
+        builder.Entity<TrainerAvailability>().HasQueryFilter(e =>
             _tenant.OrganizationId == Guid.Empty || e.OrganizationId == _tenant.OrganizationId);
     }
 

--- a/backend/CoachOS.Infrastructure/Persistence/Configurations/TrainerAvailabilityConfiguration.cs
+++ b/backend/CoachOS.Infrastructure/Persistence/Configurations/TrainerAvailabilityConfiguration.cs
@@ -1,0 +1,31 @@
+using CoachOS.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace CoachOS.Infrastructure.Persistence.Configurations;
+
+public class TrainerAvailabilityConfiguration : IEntityTypeConfiguration<TrainerAvailability>
+{
+    public void Configure(EntityTypeBuilder<TrainerAvailability> builder)
+    {
+        builder.HasKey(a => a.Id);
+
+        builder.Property(a => a.DayOfWeek).IsRequired();
+        builder.Property(a => a.StartTime).IsRequired();
+        builder.Property(a => a.EndTime).IsRequired();
+        builder.Property(a => a.IsActive).IsRequired();
+
+        builder.HasOne(a => a.Organization)
+            .WithMany()
+            .HasForeignKey(a => a.OrganizationId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(a => a.TennisClub)
+            .WithMany()
+            .HasForeignKey(a => a.TennisClubId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasIndex(a => a.OrganizationId);
+        builder.HasIndex(a => new { a.TrainerId, a.DayOfWeek });
+    }
+}

--- a/backend/CoachOS.Infrastructure/Repositories/TrainerAvailabilityRepository.cs
+++ b/backend/CoachOS.Infrastructure/Repositories/TrainerAvailabilityRepository.cs
@@ -1,0 +1,38 @@
+using CoachOS.Domain.Entities;
+using CoachOS.Domain.Interfaces;
+using CoachOS.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace CoachOS.Infrastructure.Repositories;
+
+public class TrainerAvailabilityRepository(ApplicationDbContext db) : ITrainerAvailabilityRepository
+{
+    public async Task<IReadOnlyList<TrainerAvailability>> GetByOrganizationAsync(Guid organizationId, CancellationToken ct = default)
+        => await db.TrainerAvailabilities
+            .AsNoTracking()
+            .Include(a => a.TennisClub)
+            .Where(a => a.OrganizationId == organizationId && a.IsActive)
+            .OrderBy(a => a.DayOfWeek)
+            .ThenBy(a => a.StartTime)
+            .ToListAsync(ct);
+
+    public async Task<TrainerAvailability?> GetByIdAsync(Guid id, Guid organizationId, CancellationToken ct = default)
+        => await db.TrainerAvailabilities
+            .FirstOrDefaultAsync(a => a.Id == id && a.OrganizationId == organizationId && a.IsActive, ct);
+
+    public async Task<bool> HasOverlapAsync(Guid trainerId, Guid organizationId, int dayOfWeek, TimeOnly startTime, TimeOnly endTime, CancellationToken ct = default)
+        => await db.TrainerAvailabilities
+            .AsNoTracking()
+            .AnyAsync(a => a.TrainerId == trainerId
+                && a.OrganizationId == organizationId
+                && a.DayOfWeek == dayOfWeek
+                && a.IsActive
+                && a.StartTime < endTime
+                && a.EndTime > startTime, ct);
+
+    public async Task AddAsync(TrainerAvailability availability, CancellationToken ct = default)
+        => await db.TrainerAvailabilities.AddAsync(availability, ct);
+
+    public async Task SaveChangesAsync(CancellationToken ct = default)
+        => await db.SaveChangesAsync(ct);
+}

--- a/backend/CoachOS.Tests/Mappings/ApplicationMapperTests.cs
+++ b/backend/CoachOS.Tests/Mappings/ApplicationMapperTests.cs
@@ -1,5 +1,6 @@
 using CoachOS.Application.LessonSerie.DTOs;
 using CoachOS.Application.Mappings;
+using CoachOS.Application.TrainerAvailabilities.DTOs;
 using CoachOS.Domain.Entities;
 using FluentAssertions;
 using NUnit.Framework;
@@ -136,5 +137,52 @@ public class ApplicationMapperTests
         var series = _mapper.ToLessonSerie(request, OrgId);
 
         series.MaxRegistrations.Should().BeNull();
+    }
+
+    // ── ToTrainerAvailability ────────────────────────────────────────────────
+
+    [Test]
+    public void ToTrainerAvailability_MapsAllFields()
+    {
+        Guid orgId = Guid.NewGuid();
+        CreateTrainerAvailabilityRequest request = new(Guid.NewGuid(), Guid.NewGuid(), 2, "17:30", "21:00");
+
+        TrainerAvailability entity = _mapper.ToTrainerAvailability(request, orgId);
+
+        entity.Id.Should().NotBeEmpty();
+        entity.OrganizationId.Should().Be(orgId);
+        entity.TrainerId.Should().Be(request.TrainerId);
+        entity.TennisClubId.Should().Be(request.TennisClubId);
+        entity.DayOfWeek.Should().Be(2);
+        entity.StartTime.Should().Be(new TimeOnly(17, 30));
+        entity.EndTime.Should().Be(new TimeOnly(21, 0));
+        entity.IsActive.Should().BeTrue();
+    }
+
+    [Test]
+    public void ToTrainerAvailabilityDto_MapsAllFields()
+    {
+        TrainerAvailability entity = new()
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = Guid.NewGuid(),
+            TrainerId = Guid.NewGuid(),
+            TennisClubId = Guid.NewGuid(),
+            DayOfWeek = 4,
+            StartTime = new TimeOnly(9, 0),
+            EndTime = new TimeOnly(12, 30),
+            IsActive = true,
+            TennisClub = new TennisClub { Name = "TC Demo" },
+        };
+
+        TrainerAvailabilityDto dto = _mapper.ToTrainerAvailabilityDto(entity);
+
+        dto.Id.Should().Be(entity.Id);
+        dto.TrainerId.Should().Be(entity.TrainerId);
+        dto.TennisClubId.Should().Be(entity.TennisClubId);
+        dto.TennisClubName.Should().Be("TC Demo");
+        dto.DayOfWeek.Should().Be(4);
+        dto.StartTime.Should().Be("09:00");
+        dto.EndTime.Should().Be("12:30");
     }
 }

--- a/backend/CoachOS.Tests/Services/TrainerAvailabilityServiceTests.cs
+++ b/backend/CoachOS.Tests/Services/TrainerAvailabilityServiceTests.cs
@@ -1,0 +1,167 @@
+using CoachOS.Application.Mappings;
+using CoachOS.Application.TrainerAvailabilities;
+using CoachOS.Application.TrainerAvailabilities.DTOs;
+using CoachOS.Domain.Entities;
+using CoachOS.Domain.Interfaces;
+using CoachOS.Domain.Models;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+
+namespace CoachOS.Tests.Services;
+
+[TestFixture]
+public class TrainerAvailabilityServiceTests
+{
+    private Mock<ITrainerAvailabilityRepository> _repo = null!;
+    private Mock<ITennisClubRepository> _clubRepo = null!;
+    private Mock<IUserLookupService> _userLookup = null!;
+    private ApplicationMapper _mapper = null!;
+    private TrainerAvailabilityService _sut = null!;
+
+    private readonly Guid _orgId = Guid.NewGuid();
+    private readonly Guid _trainerId = Guid.NewGuid();
+    private readonly Guid _clubId = Guid.NewGuid();
+
+    [SetUp]
+    public void SetUp()
+    {
+        _repo = new Mock<ITrainerAvailabilityRepository>();
+        _clubRepo = new Mock<ITennisClubRepository>();
+        _userLookup = new Mock<IUserLookupService>();
+        _mapper = new ApplicationMapper();
+        _sut = new TrainerAvailabilityService(_repo.Object, _clubRepo.Object, _userLookup.Object, _mapper);
+    }
+
+    private CreateTrainerAvailabilityRequest ValidRequest() =>
+        new(_trainerId, _clubId, 0, "17:00", "21:00");
+
+    private void SetupHappyPath()
+    {
+        _clubRepo.Setup(r => r.ExistsAsync(_clubId, _orgId, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _userLookup.Setup(r => r.IsActiveTrainerAsync(_trainerId, _orgId, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _repo.Setup(r => r.HasOverlapAsync(_trainerId, _orgId, 0, It.IsAny<TimeOnly>(), It.IsAny<TimeOnly>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+    }
+
+    [Test]
+    public async Task CreateAsync_ValidRequest_AddsAndReturnsId()
+    {
+        SetupHappyPath();
+
+        Result<Guid> result = await _sut.CreateAsync(_orgId, ValidRequest(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeEmpty();
+        _repo.Verify(r => r.AddAsync(
+            It.Is<TrainerAvailability>(a =>
+                a.OrganizationId == _orgId
+                && a.TrainerId == _trainerId
+                && a.TennisClubId == _clubId
+                && a.DayOfWeek == 0
+                && a.StartTime == new TimeOnly(17, 0)
+                && a.EndTime == new TimeOnly(21, 0)
+                && a.IsActive),
+            It.IsAny<CancellationToken>()), Times.Once);
+        _repo.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task CreateAsync_ClubNotInOrganization_ReturnsNotFound()
+    {
+        SetupHappyPath();
+        _clubRepo.Setup(r => r.ExistsAsync(_clubId, _orgId, It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        Result<Guid> result = await _sut.CreateAsync(_orgId, ValidRequest(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Code == ErrorCodes.NotFound);
+        _repo.Verify(r => r.AddAsync(It.IsAny<TrainerAvailability>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task CreateAsync_NotAnActiveTrainer_ReturnsNotFound()
+    {
+        SetupHappyPath();
+        _userLookup.Setup(r => r.IsActiveTrainerAsync(_trainerId, _orgId, It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        Result<Guid> result = await _sut.CreateAsync(_orgId, ValidRequest(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Code == ErrorCodes.NotFound);
+        _repo.Verify(r => r.AddAsync(It.IsAny<TrainerAvailability>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task CreateAsync_OverlappingAvailability_ReturnsConflict()
+    {
+        SetupHappyPath();
+        _repo.Setup(r => r.HasOverlapAsync(_trainerId, _orgId, 0, It.IsAny<TimeOnly>(), It.IsAny<TimeOnly>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        Result<Guid> result = await _sut.CreateAsync(_orgId, ValidRequest(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Code == ErrorCodes.Conflict);
+        _repo.Verify(r => r.AddAsync(It.IsAny<TrainerAvailability>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task GetAllAsync_ReturnsMappedDtos()
+    {
+        TrainerAvailability entity = new()
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = _orgId,
+            TrainerId = _trainerId,
+            TennisClubId = _clubId,
+            DayOfWeek = 3,
+            StartTime = new TimeOnly(18, 0),
+            EndTime = new TimeOnly(22, 0),
+            IsActive = true,
+            TennisClub = new TennisClub { Name = "TC Demo" },
+        };
+        _repo.Setup(r => r.GetByOrganizationAsync(_orgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<TrainerAvailability> { entity });
+
+        Result<List<TrainerAvailabilityDto>> result = await _sut.GetAllAsync(_orgId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(1);
+        result.Value![0].TennisClubName.Should().Be("TC Demo");
+        result.Value![0].StartTime.Should().Be("18:00");
+    }
+
+    [Test]
+    public async Task DeleteAsync_Existing_SoftDeletes()
+    {
+        TrainerAvailability entity = new()
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = _orgId,
+            TrainerId = _trainerId,
+            TennisClubId = _clubId,
+            IsActive = true,
+        };
+        _repo.Setup(r => r.GetByIdAsync(entity.Id, _orgId, It.IsAny<CancellationToken>())).ReturnsAsync(entity);
+
+        Result result = await _sut.DeleteAsync(entity.Id, _orgId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        entity.IsActive.Should().BeFalse();
+        _repo.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task DeleteAsync_NotFound_ReturnsNotFound()
+    {
+        _repo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), _orgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TrainerAvailability?)null);
+
+        Result result = await _sut.DeleteAsync(Guid.NewGuid(), _orgId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Code == ErrorCodes.NotFound);
+        _repo.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/backend/CoachOS.Tests/Services/TrainerAvailabilityServiceTests.cs
+++ b/backend/CoachOS.Tests/Services/TrainerAvailabilityServiceTests.cs
@@ -67,6 +67,21 @@ public class TrainerAvailabilityServiceTests
     }
 
     [Test]
+    public async Task CreateAsync_NoClub_SkipsClubCheckAndSucceeds()
+    {
+        SetupHappyPath();
+        CreateTrainerAvailabilityRequest request = ValidRequest() with { TennisClubId = null };
+
+        Result<Guid> result = await _sut.CreateAsync(_orgId, request, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _clubRepo.Verify(r => r.ExistsAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+        _repo.Verify(r => r.AddAsync(
+            It.Is<TrainerAvailability>(a => a.TennisClubId == null && a.TrainerId == _trainerId),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
     public async Task CreateAsync_ClubNotInOrganization_ReturnsNotFound()
     {
         SetupHappyPath();

--- a/backend/CoachOS.Tests/Validators/CreateTrainerAvailabilityRequestValidatorTests.cs
+++ b/backend/CoachOS.Tests/Validators/CreateTrainerAvailabilityRequestValidatorTests.cs
@@ -33,11 +33,19 @@ public class CreateTrainerAvailabilityRequestValidatorTests
     }
 
     [Test]
+    public void Validate_NullTennisClubId_Passes()
+    {
+        // Null = beschikbaar bij eender welke club -> toegestaan.
+        ValidationResult result = _validator.Validate(Valid() with { TennisClubId = null });
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Test]
     public void Validate_EmptyTennisClubId_Fails()
     {
         ValidationResult result = _validator.Validate(Valid() with { TennisClubId = Guid.Empty });
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.ErrorMessage == "Club is verplicht");
+        result.Errors.Should().Contain(e => e.ErrorMessage == "Ongeldige club");
     }
 
     [TestCase(-1)]

--- a/backend/CoachOS.Tests/Validators/CreateTrainerAvailabilityRequestValidatorTests.cs
+++ b/backend/CoachOS.Tests/Validators/CreateTrainerAvailabilityRequestValidatorTests.cs
@@ -1,0 +1,78 @@
+using CoachOS.Application.TrainerAvailabilities.DTOs;
+using CoachOS.Application.TrainerAvailabilities.Validators;
+using FluentAssertions;
+using FluentValidation.Results;
+using NUnit.Framework;
+
+namespace CoachOS.Tests.Validators;
+
+[TestFixture]
+public class CreateTrainerAvailabilityRequestValidatorTests
+{
+    private CreateTrainerAvailabilityRequestValidator _validator = null!;
+
+    [SetUp]
+    public void SetUp() => _validator = new CreateTrainerAvailabilityRequestValidator();
+
+    private static CreateTrainerAvailabilityRequest Valid() =>
+        new(Guid.NewGuid(), Guid.NewGuid(), 0, "17:00", "21:00");
+
+    [Test]
+    public void Validate_ValidRequest_Passes()
+    {
+        ValidationResult result = _validator.Validate(Valid());
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Test]
+    public void Validate_EmptyTrainerId_Fails()
+    {
+        ValidationResult result = _validator.Validate(Valid() with { TrainerId = Guid.Empty });
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.ErrorMessage == "Trainer is verplicht");
+    }
+
+    [Test]
+    public void Validate_EmptyTennisClubId_Fails()
+    {
+        ValidationResult result = _validator.Validate(Valid() with { TennisClubId = Guid.Empty });
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.ErrorMessage == "Club is verplicht");
+    }
+
+    [TestCase(-1)]
+    [TestCase(7)]
+    public void Validate_DayOfWeekOutOfRange_Fails(int day)
+    {
+        ValidationResult result = _validator.Validate(Valid() with { DayOfWeek = day });
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.ErrorMessage == "Ongeldige weekdag");
+    }
+
+    [TestCase("25:00")]
+    [TestCase("9:00")]
+    [TestCase("")]
+    [TestCase("abc")]
+    public void Validate_InvalidStartTime_Fails(string startTime)
+    {
+        ValidationResult result = _validator.Validate(Valid() with { StartTime = startTime });
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.ErrorMessage == "Ongeldige starttijd (HH:mm)");
+    }
+
+    [Test]
+    public void Validate_EndTimeBeforeStartTime_Fails()
+    {
+        ValidationResult result = _validator.Validate(Valid() with { StartTime = "21:00", EndTime = "17:00" });
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.ErrorMessage == "Eindtijd moet na starttijd zijn");
+    }
+
+    [Test]
+    public void Validate_EndTimeEqualsStartTime_Fails()
+    {
+        ValidationResult result = _validator.Validate(Valid() with { StartTime = "17:00", EndTime = "17:00" });
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.ErrorMessage == "Eindtijd moet na starttijd zijn");
+    }
+}

--- a/backend/Scripts/seed-demo-data.py
+++ b/backend/Scripts/seed-demo-data.py
@@ -196,18 +196,23 @@ def create_trainer_availabilities(api: ApiClient, club_ids: list[str]) -> None:
         print("   No active trainers - skipping availabilities.")
         return
 
+    # clubIndex None = club-loze beschikbaarheid (geldt voor eender welke club).
     plans = [
         {"dayOfWeek": 0, "clubIndex": 0, "startTime": "17:00", "endTime": "21:00"},
-        {"dayOfWeek": 2, "clubIndex": 1, "startTime": "18:00", "endTime": "22:00"},
+        {"dayOfWeek": 2, "clubIndex": None, "startTime": "18:00", "endTime": "22:00"},
     ]
 
     created = 0
     for trainer in active:
         for plan in plans:
-            club_idx = min(plan["clubIndex"], len(club_ids) - 1)
+            if plan["clubIndex"] is None:
+                tennis_club_id = None
+            else:
+                club_idx = min(plan["clubIndex"], len(club_ids) - 1)
+                tennis_club_id = club_ids[club_idx]
             body = {
                 "trainerId": trainer["id"],
-                "tennisClubId": club_ids[club_idx],
+                "tennisClubId": tennis_club_id,
                 "dayOfWeek": plan["dayOfWeek"],
                 "startTime": plan["startTime"],
                 "endTime": plan["endTime"],

--- a/backend/Scripts/seed-demo-data.py
+++ b/backend/Scripts/seed-demo-data.py
@@ -180,6 +180,47 @@ def invite_trainers_and_pick_id(api: ApiClient, trainers: list[dict],
     return active[0]["id"] if active else fallback_user_id
 
 
+def create_trainer_availabilities(api: ApiClient, club_ids: list[str]) -> None:
+    """Legt per actieve trainer een paar vaste beschikbaarheden vast (demo-data).
+    Club x weekdag x tijdvak. dayOfWeek: 0 = maandag ... 6 = zondag. De twee
+    slots staan op verschillende dagen zodat de per-trainer overlap-check niet
+    afgaat."""
+    print("\n3b. Creating trainer availabilities...")
+    if not club_ids:
+        print("   No clubs - skipping availabilities.")
+        return
+
+    trainer_list = api.get("/trainers") or []
+    active = [t for t in trainer_list if t.get("isActive")]
+    if not active:
+        print("   No active trainers - skipping availabilities.")
+        return
+
+    plans = [
+        {"dayOfWeek": 0, "clubIndex": 0, "startTime": "17:00", "endTime": "21:00"},
+        {"dayOfWeek": 2, "clubIndex": 1, "startTime": "18:00", "endTime": "22:00"},
+    ]
+
+    created = 0
+    for trainer in active:
+        for plan in plans:
+            club_idx = min(plan["clubIndex"], len(club_ids) - 1)
+            body = {
+                "trainerId": trainer["id"],
+                "tennisClubId": club_ids[club_idx],
+                "dayOfWeek": plan["dayOfWeek"],
+                "startTime": plan["startTime"],
+                "endTime": plan["endTime"],
+            }
+            result = api.post("/trainer-availabilities", body)
+            if result is not None:
+                created += 1
+            else:
+                print(f"   ERR availability for {trainer.get('email')} failed "
+                      f"(see stderr)", file=sys.stderr)
+    print(f"   Created {created} availabilities for {len(active)} trainer(s)")
+
+
 def create_simple_series(api: ApiClient, series_specs: list[dict],
                          club_ids: list[str], trainer_id: str,
                          today: date, deadline_iso: str) -> list[str]:
@@ -429,6 +470,7 @@ def main() -> int:
     club_ids = create_clubs(api, data["clubs"])
     trainer_id = invite_trainers_and_pick_id(
         api, data["trainers"], auth["userId"])
+    create_trainer_availabilities(api, club_ids)
 
     simple_ids = create_simple_series(
         api, data["simpleSeries"], club_ids, trainer_id, today, deadline_iso)

--- a/frontend/app/(dashboard)/dashboard/lessons/new/_components/calendar-week-view.tsx
+++ b/frontend/app/(dashboard)/dashboard/lessons/new/_components/calendar-week-view.tsx
@@ -48,12 +48,14 @@ interface CalendarWeekViewProps {
   slots: WizardSlot[];
   onChange: (slots: WizardSlot[]) => void;
   defaults?: SlotDefaults;
+  tennisClubId: string;
 }
 
 export function CalendarWeekView({
   slots,
   onChange,
   defaults,
+  tennisClubId,
 }: CalendarWeekViewProps) {
   const t = useTranslations("lessonWizard");
   const gridBodyRef = useRef<HTMLDivElement>(null);
@@ -392,6 +394,7 @@ export function CalendarWeekView({
             <SlotEditPopover
               slot={editingSlot}
               anchorRef={editAnchor}
+              tennisClubId={tennisClubId}
               onSave={handleSlotSave}
               onClose={() => setEditingSlotId(null)}
             />

--- a/frontend/app/(dashboard)/dashboard/lessons/new/_components/slot-edit-popover.tsx
+++ b/frontend/app/(dashboard)/dashboard/lessons/new/_components/slot-edit-popover.tsx
@@ -17,12 +17,14 @@ import {
 } from "@/components/ui/select";
 import { LESSON_LEVELS } from "@/lib/api/lessonSeries";
 import { getTrainers, isAssignableTrainer } from "@/lib/api/trainers";
+import { getTrainerAvailabilities } from "@/lib/api/trainerAvailabilities";
 import { inputClass } from "@/lib/styles";
 import type { WizardSlot } from "../_types";
 
 interface SlotEditPopoverProps {
   slot: WizardSlot;
   anchorRef: HTMLElement;
+  tennisClubId: string;
   onSave: (updated: WizardSlot) => void;
   onClose: () => void;
 }
@@ -30,6 +32,7 @@ interface SlotEditPopoverProps {
 export function SlotEditPopover({
   slot,
   anchorRef,
+  tennisClubId,
   onSave,
   onClose,
 }: SlotEditPopoverProps) {
@@ -40,6 +43,11 @@ export function SlotEditPopover({
     queryFn: getTrainers,
   });
   const assignableTrainers = trainers.filter(isAssignableTrainer);
+
+  const { data: availabilities = [] } = useQuery({
+    queryKey: ["trainerAvailabilities"],
+    queryFn: getTrainerAvailabilities,
+  });
 
   const [trainerId, setTrainerId] = useState(slot.trainerId ?? "none");
   const [startTime, setStartTime] = useState(slot.startTime);
@@ -59,6 +67,26 @@ export function SlotEditPopover({
     setMaxStudents(slot.maxStudents);
     setLevel(slot.level !== null ? String(slot.level) : "none");
   }, [slot.id]);
+
+  const availableTrainerIds = new Set(
+    availabilities
+      .filter(
+        (a) => a.tennisClubId === tennisClubId && a.dayOfWeek === slot.dayOfWeek
+      )
+      .map((a) => a.trainerId)
+  );
+  const trainersWithKnownAvailability = new Set(
+    availabilities.map((a) => a.trainerId)
+  );
+  const sortedAssignableTrainers = [...assignableTrainers].sort(
+    (a, b) =>
+      Number(availableTrainerIds.has(b.id)) -
+      Number(availableTrainerIds.has(a.id))
+  );
+  const showUnavailableWarning =
+    trainerId !== "none" &&
+    trainersWithKnownAvailability.has(trainerId) &&
+    !availableTrainerIds.has(trainerId);
 
   function handleSave() {
     const trainer = trainers.find((tr) => tr.id === trainerId);
@@ -130,13 +158,23 @@ export function SlotEditPopover({
               <SelectItem value="none">
                 <span className="text-gray-400">{t("nonePicker")}</span>
               </SelectItem>
-              {assignableTrainers.map((tr) => (
+              {sortedAssignableTrainers.map((tr) => (
                 <SelectItem key={tr.id} value={tr.id}>
                   {tr.firstName} {tr.lastName}
+                  {availableTrainerIds.has(tr.id) && (
+                    <span className="ml-2 text-xs text-tennis-green">
+                      {"✓"} {t("availableBadge")}
+                    </span>
+                  )}
                 </SelectItem>
               ))}
             </SelectContent>
           </Select>
+          {showUnavailableWarning && (
+            <p className="mt-1 text-[11px] text-amber-600">
+              {t("trainerNotAvailableWarning")}
+            </p>
+          )}
         </div>
 
         {/* Court name */}

--- a/frontend/app/(dashboard)/dashboard/lessons/new/_components/slot-edit-popover.tsx
+++ b/frontend/app/(dashboard)/dashboard/lessons/new/_components/slot-edit-popover.tsx
@@ -70,8 +70,11 @@ export function SlotEditPopover({
 
   const availableTrainerIds = new Set(
     availabilities
+      // null club = beschikbaar bij eender welke club -> matcht deze club ook.
       .filter(
-        (a) => a.tennisClubId === tennisClubId && a.dayOfWeek === slot.dayOfWeek
+        (a) =>
+          (a.tennisClubId === null || a.tennisClubId === tennisClubId) &&
+          a.dayOfWeek === slot.dayOfWeek
       )
       .map((a) => a.trainerId)
   );

--- a/frontend/app/(dashboard)/dashboard/lessons/new/_components/slot-edit-popover.tsx
+++ b/frontend/app/(dashboard)/dashboard/lessons/new/_components/slot-edit-popover.tsx
@@ -163,12 +163,16 @@ export function SlotEditPopover({
               </SelectItem>
               {sortedAssignableTrainers.map((tr) => (
                 <SelectItem key={tr.id} value={tr.id}>
-                  {tr.firstName} {tr.lastName}
-                  {availableTrainerIds.has(tr.id) && (
-                    <span className="ml-2 text-xs text-tennis-green">
-                      {"✓"} {t("availableBadge")}
-                    </span>
-                  )}
+                  <span className="inline-flex items-center gap-1.5">
+                    {availableTrainerIds.has(tr.id) && (
+                      <span
+                        className="h-1.5 w-1.5 shrink-0 rounded-full bg-tennis-green"
+                        title={t("availableBadge")}
+                        aria-label={t("availableBadge")}
+                      />
+                    )}
+                    {tr.firstName} {tr.lastName}
+                  </span>
                 </SelectItem>
               ))}
             </SelectContent>

--- a/frontend/app/(dashboard)/dashboard/lessons/new/_components/step-2-planning.tsx
+++ b/frontend/app/(dashboard)/dashboard/lessons/new/_components/step-2-planning.tsx
@@ -47,7 +47,8 @@ export function Step2Planning({
 
   const clubTrainerIds = new Set(
     availabilities
-      .filter((a) => a.tennisClubId === tennisClubId)
+      // null club = beschikbaar bij eender welke club -> matcht deze club ook.
+      .filter((a) => a.tennisClubId === null || a.tennisClubId === tennisClubId)
       .map((a) => a.trainerId)
   );
   const sortedAssignableTrainers = [...assignableTrainers].sort(

--- a/frontend/app/(dashboard)/dashboard/lessons/new/_components/step-2-planning.tsx
+++ b/frontend/app/(dashboard)/dashboard/lessons/new/_components/step-2-planning.tsx
@@ -13,18 +13,21 @@ import {
 } from "@/components/ui/select";
 import { LESSON_LEVELS } from "@/lib/api/lessonSeries";
 import { getTrainers, isAssignableTrainer } from "@/lib/api/trainers";
+import { getTrainerAvailabilities } from "@/lib/api/trainerAvailabilities";
 import { inputClass } from "@/lib/styles";
 import type { WizardSlot } from "../_types";
 import { CalendarWeekView, type SlotDefaults } from "./calendar-week-view";
 
 interface Step2Props {
   slots: WizardSlot[];
+  tennisClubId: string;
   onNext: (slots: WizardSlot[]) => void;
   onBack: () => void;
 }
 
 export function Step2Planning({
   slots: initialSlots,
+  tennisClubId,
   onNext,
   onBack,
 }: Step2Props) {
@@ -36,6 +39,20 @@ export function Step2Planning({
     queryFn: getTrainers,
   });
   const assignableTrainers = trainers.filter(isAssignableTrainer);
+
+  const { data: availabilities = [] } = useQuery({
+    queryKey: ["trainerAvailabilities"],
+    queryFn: getTrainerAvailabilities,
+  });
+
+  const clubTrainerIds = new Set(
+    availabilities
+      .filter((a) => a.tennisClubId === tennisClubId)
+      .map((a) => a.trainerId)
+  );
+  const sortedAssignableTrainers = [...assignableTrainers].sort(
+    (a, b) => Number(clubTrainerIds.has(b.id)) - Number(clubTrainerIds.has(a.id))
+  );
 
   const [defaults, setDefaults] = useState<SlotDefaults>({
     trainerId: null,
@@ -83,6 +100,7 @@ export function Step2Planning({
             slots={slots}
             onChange={setSlots}
             defaults={defaults}
+            tennisClubId={tennisClubId}
           />
         </div>
 
@@ -114,9 +132,14 @@ export function Step2Planning({
                   <SelectItem value="none">
                     <span className="text-gray-400">{t("nonePicker")}</span>
                   </SelectItem>
-                  {assignableTrainers.map((tr) => (
+                  {sortedAssignableTrainers.map((tr) => (
                     <SelectItem key={tr.id} value={tr.id}>
                       {tr.firstName} {tr.lastName}
+                      {clubTrainerIds.has(tr.id) && (
+                        <span className="ml-2 text-xs text-tennis-green">
+                          {"✓"} {t("availableBadge")}
+                        </span>
+                      )}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/frontend/app/(dashboard)/dashboard/lessons/new/_components/step-2-planning.tsx
+++ b/frontend/app/(dashboard)/dashboard/lessons/new/_components/step-2-planning.tsx
@@ -135,12 +135,16 @@ export function Step2Planning({
                   </SelectItem>
                   {sortedAssignableTrainers.map((tr) => (
                     <SelectItem key={tr.id} value={tr.id}>
-                      {tr.firstName} {tr.lastName}
-                      {clubTrainerIds.has(tr.id) && (
-                        <span className="ml-2 text-xs text-tennis-green">
-                          {"✓"} {t("availableBadge")}
-                        </span>
-                      )}
+                      <span className="inline-flex items-center gap-1.5">
+                        {clubTrainerIds.has(tr.id) && (
+                          <span
+                            className="h-1.5 w-1.5 shrink-0 rounded-full bg-tennis-green"
+                            title={t("availableBadge")}
+                            aria-label={t("availableBadge")}
+                          />
+                        )}
+                        {tr.firstName} {tr.lastName}
+                      </span>
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/frontend/app/(dashboard)/dashboard/lessons/new/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/lessons/new/page.tsx
@@ -150,6 +150,7 @@ export default function NewLessonSeriesPage() {
       {step === 2 && (
         <Step2Planning
           slots={weeklyTemplate}
+          tennisClubId={step1Data?.tennisClubId ?? ""}
           onNext={handleStep2Next}
           onBack={() => setStep(1)}
         />

--- a/frontend/app/(dashboard)/dashboard/trainers/_components/trainer-availability-dialog.tsx
+++ b/frontend/app/(dashboard)/dashboard/trainers/_components/trainer-availability-dialog.tsx
@@ -83,10 +83,9 @@ export function TrainerAvailabilityDialog({
   });
 
   function handleAdd() {
-    if (!clubId) return;
     createMutation.mutate({
       trainerId: trainer.id,
-      tennisClubId: clubId,
+      tennisClubId: clubId || null,
       dayOfWeek,
       startTime,
       endTime,
@@ -115,8 +114,8 @@ export function TrainerAvailabilityDialog({
               className="flex items-center justify-between rounded-lg border border-gray-200 px-3 py-2 text-sm"
             >
               <span>
-                {a.tennisClubName}, {DAY_NAMES_FULL[a.dayOfWeek]}{" "}
-                {a.startTime} tot {a.endTime}
+                {a.tennisClubName ?? t("availabilityAnyClub")},{" "}
+                {DAY_NAMES_FULL[a.dayOfWeek]} {a.startTime} tot {a.endTime}
               </span>
               <button
                 type="button"
@@ -142,7 +141,7 @@ export function TrainerAvailabilityDialog({
                 value={clubId}
                 onChange={(e) => setClubId(e.target.value)}
               >
-                <option value="">{t("availabilityClubPlaceholder")}</option>
+                <option value="">{t("availabilityAnyClub")}</option>
                 {clubs.map((club) => (
                   <option key={club.id} value={club.id}>
                     {club.name}
@@ -200,7 +199,7 @@ export function TrainerAvailabilityDialog({
           <button
             type="button"
             onClick={handleAdd}
-            disabled={createMutation.isPending || !clubId}
+            disabled={createMutation.isPending}
             className="w-full flex items-center justify-center gap-2 px-4 py-2 text-sm font-semibold text-white bg-tennis-green rounded-lg hover:bg-tennis-green/90 transition-colors disabled:opacity-50"
           >
             <Plus className="h-4 w-4" />

--- a/frontend/app/(dashboard)/dashboard/trainers/_components/trainer-availability-dialog.tsx
+++ b/frontend/app/(dashboard)/dashboard/trainers/_components/trainer-availability-dialog.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useTranslations } from "next-intl";
+import { Trash2, Plus } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { NativeSelect } from "@/components/ui/native-select";
+import { inputClass } from "@/lib/styles";
+import { getTennisClubs } from "@/lib/api/tennisClubs";
+import {
+  getTrainerAvailabilities,
+  createTrainerAvailability,
+  deleteTrainerAvailability,
+  type TrainerAvailabilityDto,
+} from "@/lib/api/trainerAvailabilities";
+import { getAxiosErrorMessages } from "@/lib/utils/api-errors";
+import type { TrainerDto } from "@/lib/api/trainers";
+
+const DAY_NAMES_FULL = [
+  "Maandag",
+  "Dinsdag",
+  "Woensdag",
+  "Donderdag",
+  "Vrijdag",
+  "Zaterdag",
+  "Zondag",
+];
+
+interface TrainerAvailabilityDialogProps {
+  trainer: TrainerDto;
+  onClose: () => void;
+}
+
+export function TrainerAvailabilityDialog({
+  trainer,
+  onClose,
+}: TrainerAvailabilityDialogProps) {
+  const t = useTranslations("trainers");
+  const queryClient = useQueryClient();
+
+  const [clubId, setClubId] = useState("");
+  const [dayOfWeek, setDayOfWeek] = useState(0);
+  const [startTime, setStartTime] = useState("17:00");
+  const [endTime, setEndTime] = useState("21:00");
+  const [errorMessages, setErrorMessages] = useState<string[]>([]);
+
+  const { data: clubs = [] } = useQuery({
+    queryKey: ["tennisClubs"],
+    queryFn: getTennisClubs,
+  });
+
+  const { data: availabilities = [] } = useQuery({
+    queryKey: ["trainerAvailabilities"],
+    queryFn: getTrainerAvailabilities,
+  });
+
+  const trainerAvailabilities = availabilities.filter(
+    (a) => a.trainerId === trainer.id
+  );
+
+  const createMutation = useMutation({
+    mutationFn: createTrainerAvailability,
+    onSuccess: () => {
+      setErrorMessages([]);
+      queryClient.invalidateQueries({ queryKey: ["trainerAvailabilities"] });
+    },
+    onError: (error) => setErrorMessages(getAxiosErrorMessages(error)),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteTrainerAvailability,
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["trainerAvailabilities"] }),
+    onError: (error) => setErrorMessages(getAxiosErrorMessages(error)),
+  });
+
+  function handleAdd() {
+    if (!clubId) return;
+    createMutation.mutate({
+      trainerId: trainer.id,
+      tennisClubId: clubId,
+      dayOfWeek,
+      startTime,
+      endTime,
+    });
+  }
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-lg" aria-describedby={undefined}>
+        <DialogHeader>
+          <DialogTitle>
+            {t("availabilityTitle", {
+              name: `${trainer.firstName} ${trainer.lastName}`,
+            })}
+          </DialogTitle>
+        </DialogHeader>
+
+        {/* Bestaande beschikbaarheden */}
+        <div className="space-y-2">
+          {trainerAvailabilities.length === 0 && (
+            <p className="text-sm text-gray-500">{t("availabilityEmpty")}</p>
+          )}
+          {trainerAvailabilities.map((a: TrainerAvailabilityDto) => (
+            <div
+              key={a.id}
+              className="flex items-center justify-between rounded-lg border border-gray-200 px-3 py-2 text-sm"
+            >
+              <span>
+                {a.tennisClubName}, {DAY_NAMES_FULL[a.dayOfWeek]}{" "}
+                {a.startTime} tot {a.endTime}
+              </span>
+              <button
+                type="button"
+                onClick={() => deleteMutation.mutate(a.id)}
+                disabled={deleteMutation.isPending}
+                className="text-gray-400 hover:text-red-600 transition-colors"
+                aria-label={t("availabilityDelete")}
+              >
+                <Trash2 className="h-4 w-4" />
+              </button>
+            </div>
+          ))}
+        </div>
+
+        {/* Nieuwe beschikbaarheid */}
+        <div className="border-t border-gray-100 pt-4 space-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1.5">
+                {t("availabilityClub")}
+              </label>
+              <NativeSelect
+                value={clubId}
+                onChange={(e) => setClubId(e.target.value)}
+              >
+                <option value="">{t("availabilityClubPlaceholder")}</option>
+                {clubs.map((club) => (
+                  <option key={club.id} value={club.id}>
+                    {club.name}
+                  </option>
+                ))}
+              </NativeSelect>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1.5">
+                {t("availabilityDay")}
+              </label>
+              <NativeSelect
+                value={dayOfWeek}
+                onChange={(e) => setDayOfWeek(Number(e.target.value))}
+              >
+                {DAY_NAMES_FULL.map((name, index) => (
+                  <option key={index} value={index}>
+                    {name}
+                  </option>
+                ))}
+              </NativeSelect>
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1.5">
+                {t("availabilityFrom")}
+              </label>
+              <input
+                type="time"
+                value={startTime}
+                onChange={(e) => setStartTime(e.target.value)}
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1.5">
+                {t("availabilityUntil")}
+              </label>
+              <input
+                type="time"
+                value={endTime}
+                onChange={(e) => setEndTime(e.target.value)}
+                className={inputClass}
+              />
+            </div>
+          </div>
+
+          {errorMessages.map((message) => (
+            <p key={message} className="text-sm text-red-600">
+              {message}
+            </p>
+          ))}
+
+          <button
+            type="button"
+            onClick={handleAdd}
+            disabled={createMutation.isPending || !clubId}
+            className="w-full flex items-center justify-center gap-2 px-4 py-2 text-sm font-semibold text-white bg-tennis-green rounded-lg hover:bg-tennis-green/90 transition-colors disabled:opacity-50"
+          >
+            <Plus className="h-4 w-4" />
+            {createMutation.isPending
+              ? t("availabilitySaving")
+              : t("availabilityAdd")}
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/app/(dashboard)/dashboard/trainers/_components/trainer-availability-dialog.tsx
+++ b/frontend/app/(dashboard)/dashboard/trainers/_components/trainer-availability-dialog.tsx
@@ -70,14 +70,16 @@ export function TrainerAvailabilityDialog({
       setErrorMessages([]);
       queryClient.invalidateQueries({ queryKey: ["trainerAvailabilities"] });
     },
-    onError: (error) => setErrorMessages(getAxiosErrorMessages(error)),
+    onError: (error) =>
+      setErrorMessages(getAxiosErrorMessages(error, t("availabilityError"))),
   });
 
   const deleteMutation = useMutation({
     mutationFn: deleteTrainerAvailability,
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ["trainerAvailabilities"] }),
-    onError: (error) => setErrorMessages(getAxiosErrorMessages(error)),
+    onError: (error) =>
+      setErrorMessages(getAxiosErrorMessages(error, t("availabilityError"))),
   });
 
   function handleAdd() {

--- a/frontend/app/(dashboard)/dashboard/trainers/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/trainers/page.tsx
@@ -14,7 +14,9 @@ import {
   X,
   Pencil,
   StickyNote,
+  CalendarClock,
 } from "lucide-react";
+import { TrainerAvailabilityDialog } from "./_components/trainer-availability-dialog";
 import { Mono } from "@/components/ui/mono";
 import {
   getTrainers,
@@ -471,6 +473,7 @@ export default function TrainersPage() {
   const [showInviteForm, setShowInviteForm] = useState(false);
   const [removeDialog, setRemoveDialog] = useState<RemoveDialogState>({ type: "none" });
   const [editTrainer, setEditTrainer] = useState<TrainerDto | null>(null);
+  const [availabilityTrainer, setAvailabilityTrainer] = useState<TrainerDto | null>(null);
   const [user, setUser] = useState<AuthUser | null>(null);
   const queryClient = useQueryClient();
   const t = useTranslations("trainers");
@@ -682,6 +685,14 @@ export default function TrainersPage() {
                         ) : (
                           <>
                             <button
+                              onClick={() => setAvailabilityTrainer(tr)}
+                              title={t("availabilityButton")}
+                              aria-label={t("availabilityButton")}
+                              className="opacity-0 group-hover:opacity-100 p-1.5 rounded text-ink-3 hover:text-tennis-green hover:bg-tennis-green/10 transition-all"
+                            >
+                              <CalendarClock size={14} />
+                            </button>
+                            <button
                               onClick={() => setEditTrainer(tr)}
                               title={t("edit")}
                               className="opacity-0 group-hover:opacity-100 p-1.5 rounded text-ink-3 hover:text-tennis-green hover:bg-tennis-green/10 transition-all"
@@ -792,6 +803,12 @@ export default function TrainersPage() {
         <EditTrainerDialog
           trainer={editTrainer}
           onClose={() => setEditTrainer(null)}
+        />
+      )}
+      {availabilityTrainer && (
+        <TrainerAvailabilityDialog
+          trainer={availabilityTrainer}
+          onClose={() => setAvailabilityTrainer(null)}
         />
       )}
     </>

--- a/frontend/lib/api/trainerAvailabilities.ts
+++ b/frontend/lib/api/trainerAvailabilities.ts
@@ -1,0 +1,38 @@
+import apiClient from "@/lib/api-client";
+
+export interface TrainerAvailabilityDto {
+  id: string;
+  trainerId: string;
+  tennisClubId: string;
+  tennisClubName: string;
+  /** 0 = maandag ... 6 = zondag */
+  dayOfWeek: number;
+  /** "HH:mm" */
+  startTime: string;
+  /** "HH:mm" */
+  endTime: string;
+}
+
+export interface CreateTrainerAvailabilityRequest {
+  trainerId: string;
+  tennisClubId: string;
+  dayOfWeek: number;
+  startTime: string;
+  endTime: string;
+}
+
+export async function getTrainerAvailabilities(): Promise<TrainerAvailabilityDto[]> {
+  const { data } = await apiClient.get<TrainerAvailabilityDto[]>("/trainer-availabilities");
+  return data;
+}
+
+export async function createTrainerAvailability(
+  request: CreateTrainerAvailabilityRequest
+): Promise<string> {
+  const { data } = await apiClient.post<string>("/trainer-availabilities", request);
+  return data;
+}
+
+export async function deleteTrainerAvailability(id: string): Promise<void> {
+  await apiClient.delete(`/trainer-availabilities/${id}`);
+}

--- a/frontend/lib/api/trainerAvailabilities.ts
+++ b/frontend/lib/api/trainerAvailabilities.ts
@@ -3,8 +3,10 @@ import apiClient from "@/lib/api-client";
 export interface TrainerAvailabilityDto {
   id: string;
   trainerId: string;
-  tennisClubId: string;
-  tennisClubName: string;
+  /** null = beschikbaar bij eender welke club */
+  tennisClubId: string | null;
+  /** null wanneer de beschikbaarheid voor eender welke club geldt */
+  tennisClubName: string | null;
   /** 0 = maandag ... 6 = zondag */
   dayOfWeek: number;
   /** "HH:mm" */
@@ -15,7 +17,8 @@ export interface TrainerAvailabilityDto {
 
 export interface CreateTrainerAvailabilityRequest {
   trainerId: string;
-  tennisClubId: string;
+  /** null = beschikbaar bij eender welke club */
+  tennisClubId: string | null;
   dayOfWeek: number;
   startTime: string;
   endTime: string;

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -207,6 +207,8 @@
     "saved": "Formulier opgeslagen"
   },
   "lessonWizard": {
+    "availableBadge": "beschikbaar",
+    "trainerNotAvailableWarning": "Deze trainer is volgens de vastgelegde beschikbaarheden niet beschikbaar in deze club op deze dag.",
     "step1Label": "Basisinfo",
     "step2Label": "Planning",
     "step3Label": "Validatie",
@@ -448,6 +450,17 @@
     "heroLabel": "/uitnodiging"
   },
   "trainers": {
+    "availabilityButton": "Beschikbaarheid",
+    "availabilityTitle": "Beschikbaarheid van {name}",
+    "availabilityEmpty": "Nog geen beschikbaarheden vastgelegd.",
+    "availabilityAdd": "Beschikbaarheid toevoegen",
+    "availabilityClub": "Club",
+    "availabilityDay": "Dag",
+    "availabilityFrom": "Van",
+    "availabilityUntil": "Tot",
+    "availabilityDelete": "Verwijderen",
+    "availabilitySaving": "Opslaan...",
+    "availabilityClubPlaceholder": "Kies een club",
     "title": "Trainers",
     "adminBadge": "Beheerder",
     "manageViaSettings": "Beheer via Instellingen",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -460,7 +460,7 @@
     "availabilityUntil": "Tot",
     "availabilityDelete": "Verwijderen",
     "availabilitySaving": "Opslaan...",
-    "availabilityClubPlaceholder": "Kies een club",
+    "availabilityAnyClub": "Alle clubs",
     "availabilityError": "Er ging iets mis. Probeer het opnieuw.",
     "title": "Trainers",
     "adminBadge": "Beheerder",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -461,6 +461,7 @@
     "availabilityDelete": "Verwijderen",
     "availabilitySaving": "Opslaan...",
     "availabilityClubPlaceholder": "Kies een club",
+    "availabilityError": "Er ging iets mis. Probeer het opnieuw.",
     "title": "Trainers",
     "adminBadge": "Beheerder",
     "manageViaSettings": "Beheer via Instellingen",


### PR DESCRIPTION
## Samenvatting

Admin kan per trainer vaste beschikbaarheden vastleggen (club x weekdag x tijdvak). Die info ondersteunt de trainerkeuze bij reeks-setup (groene "beschikbaar"-badge + sortering) en signaleert dubbelboekingen via een overlap-check. Trainer-self-service blijft bewust fase 2.

Aanleiding: klantvraag van Thomas (Tombaten, 5 clubs) die beschikbaarheden nu per mail opvraagt en trainers vooraf aan club + avond wil koppelen.

## Wat is er gebouwd

**Backend** (Clean Architecture + service pattern, `Result<T>`)
- Nieuwe `TrainerAvailability` entiteit + EF-config (`DeleteBehavior.Restrict`, indexen) + migratie `AddTrainerAvailability`
- Global tenant query-filter toegevoegd voor de nieuwe entiteit (consistent met alle andere org-scoped entities)
- Repository met `HasOverlapAsync` (overlap per trainer per weekdag, over clubs heen)
- DTOs + FluentValidation-validator (HH:mm, weekdag 0-6, eindtijd na starttijd)
- Mapper-methodes, service met org/trainer/overlap-validatie
- `GET/POST/DELETE /api/trainer-availabilities`

**Frontend** (Next.js 15 + React Query + next-intl)
- API-client + Nederlandse vertalingen (geen hardcoded strings)
- Beheer-dialog op de trainerspagina (kalender-icoon bij actieve trainers)
- Reeks-wizard: groene "beschikbaar"-badge + sortering in de defaults-kaart, plus amber soft-warning in de slot-popover wanneer de gekozen trainer niet beschikbaar is voor die club+dag (geen blokkering)

**Seed**
- Demo-beschikbaarheden toegevoegd aan `seed-demo-data.py` (stap 3b)

## Conventie-afwijkingen t.o.v. het plan (codebase was leidend)
- Tests: het project gebruikt **NUnit + Moq**, niet xUnit + NSubstitute zoals het plan aannam. Alle testcode is daarnaar vertaald.
- EF-config wordt **handmatig** geregistreerd in `OnModelCreating` (geen assembly-scan); idem tenant-filter.
- `getAxiosErrorMessages(error, fallback)` vereist een fallback-message (plan miste die).

## Test Plan
- [x] Volledige backend-suite groen: 243/243 (`dotnet test CoachOS.slnx`)
- [x] Frontend build groen (`bun run build`)
- [x] Volledige reset + seed E2E groen, inclusief nieuwe stap 3b
- [x] Migraties passen schoon toe op lege DB
- [x] Live API: GET geeft correcte DTO's (TennisClubName via Include, HH:mm), POST overlap -> 409, geldige POST -> 201, ongeldige tijden -> 400
- [ ] Handmatige UI-check van badge/warning in de wizard (visueel, openstaand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)