### PR TITLE
Website: kampen in feature showcase + grid (met animatie)

### DIFF
--- a/website/components/sections/animated-camp-mock.tsx
+++ b/website/components/sections/animated-camp-mock.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { motion, useInView, useReducedMotion } from "motion/react";
+import type { Variants } from "motion/react";
+import { Clock, GraduationCap } from "lucide-react";
+import { Mono } from "@/components/ui/mono";
+
+interface TrainerStint {
+  name: string;
+  hours: string;
+}
+
+interface CampDay {
+  day: string;
+  date: string;
+  hours: string;
+  trainers: TrainerStint[];
+}
+
+const DAYS: CampDay[] = [
+  {
+    day: "MA",
+    date: "14 apr",
+    hours: "09:00 - 16:00",
+    trainers: [
+      { name: "Jan J.", hours: "09:00 - 12:00" },
+      { name: "Pieter M.", hours: "12:00 - 16:00" },
+    ],
+  },
+  {
+    day: "DI",
+    date: "15 apr",
+    hours: "09:00 - 16:00",
+    trainers: [{ name: "Jan J.", hours: "09:00 - 16:00" }],
+  },
+  {
+    day: "WO",
+    date: "16 apr",
+    hours: "10:00 - 15:00",
+    trainers: [{ name: "Sophie D.", hours: "10:00 - 15:00" }],
+  },
+];
+
+const CAPACITY = 20;
+
+/**
+ * Live loop: enrollments tick up toward capacity. The last step flips the
+ * header badge to "Bijna vol" and stops.
+ */
+const LOOP_STEPS: number[] = [14, 16, 18, 20];
+
+const containerVariants: Variants = {
+  hidden: {},
+  visible: {
+    transition: {
+      delayChildren: 0.05,
+      staggerChildren: 0.08,
+    },
+  },
+};
+
+const dayVariants: Variants = {
+  hidden: { opacity: 0, x: -16 },
+  visible: {
+    opacity: 1,
+    x: 0,
+    transition: { type: "spring", stiffness: 220, damping: 26 },
+  },
+};
+
+const chipsContainerVariants: Variants = {
+  hidden: {},
+  visible: {
+    transition: { staggerChildren: 0.06, delayChildren: 0.04 },
+  },
+};
+
+const chipVariants: Variants = {
+  hidden: { opacity: 0, y: 8 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { type: "spring", stiffness: 260, damping: 28 },
+  },
+};
+
+const fadeUp: Variants = {
+  hidden: { opacity: 0, y: 8 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { type: "spring", stiffness: 220, damping: 26 },
+  },
+};
+
+export function AnimatedCampMock() {
+  const ref = useRef<HTMLDivElement>(null);
+  const inView = useInView(ref, { amount: 0.4, once: true });
+  const prefersReducedMotion = useReducedMotion();
+  const [step, setStep] = useState(0);
+
+  const isComplete = step >= LOOP_STEPS.length - 1;
+
+  useEffect(() => {
+    if (prefersReducedMotion || !inView || isComplete) return;
+    const t = window.setTimeout(() => {
+      setStep((s) => s + 1);
+    }, 1900);
+    return () => window.clearTimeout(t);
+  }, [step, inView, isComplete, prefersReducedMotion]);
+
+  const enrolled = prefersReducedMotion
+    ? LOOP_STEPS[LOOP_STEPS.length - 1]
+    : LOOP_STEPS[step];
+  const spotsLeft = CAPACITY - enrolled;
+
+  const animate = prefersReducedMotion || inView ? "visible" : "hidden";
+
+  return (
+    <motion.div
+      ref={ref}
+      className="relative h-full overflow-hidden bg-paper p-5"
+      initial={prefersReducedMotion ? "visible" : "hidden"}
+      animate={animate}
+      variants={containerVariants}
+    >
+      <motion.div
+        variants={fadeUp}
+        className="flex items-center justify-between"
+      >
+        <Mono className="text-[10px] tracking-[0.12em] text-ink-3">
+          PAASKAMP 2026 / TC COACHOS
+        </Mono>
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-canvas px-2.5 py-1 text-[10px] font-semibold text-ink-2">
+          <motion.span
+            className="h-1.5 w-1.5 rounded-full bg-tennis-green"
+            animate={
+              prefersReducedMotion || isComplete
+                ? undefined
+                : { opacity: [0.6, 1, 0.6], scale: [1, 1.25, 1] }
+            }
+            transition={{ duration: 1.8, repeat: Infinity, ease: "easeInOut" }}
+          />
+          {isComplete ? "Bijna vol" : "Inschrijvingen open"}
+        </span>
+      </motion.div>
+
+      <motion.h3
+        variants={fadeUp}
+        className="mt-3 text-lg font-bold tracking-tight"
+      >
+        Paaskamp Gevorderden
+      </motion.h3>
+      <motion.div variants={fadeUp}>
+        <Mono className="text-xs text-ink-3">
+          3 dagen · 14 tot 16 april · €95
+        </Mono>
+      </motion.div>
+
+      <div className="mt-5 space-y-2.5">
+        {DAYS.map((day) => (
+          <motion.div
+            key={day.day}
+            variants={dayVariants}
+            className="flex gap-3"
+          >
+            <div className="w-12 flex-shrink-0 rounded-md bg-canvas px-2 py-2 text-center">
+              <Mono className="block text-[9px] tracking-[0.12em] text-ink-3">
+                {day.day}
+              </Mono>
+              <Mono className="mt-0.5 block text-sm font-bold leading-none">
+                {day.date}
+              </Mono>
+            </div>
+            <div className="flex-1 rounded-md bg-canvas/60 px-3 py-2">
+              <div className="flex items-center gap-1.5 text-ink-2">
+                <Clock className="h-3 w-3 text-tennis-green" />
+                <Mono className="text-[11px] font-semibold text-ink">
+                  {day.hours}
+                </Mono>
+              </div>
+              <motion.div
+                variants={chipsContainerVariants}
+                className="mt-2 flex flex-wrap gap-1.5"
+              >
+                {day.trainers.map((t) => (
+                  <motion.span
+                    key={`${day.day}-${t.name}-${t.hours}`}
+                    variants={chipVariants}
+                    className="inline-flex items-center gap-1.5 rounded-full bg-white px-2 py-1 text-[10px] text-ink-2 ring-1 ring-rule"
+                  >
+                    <GraduationCap className="h-3 w-3 text-tennis-green" />
+                    <span className="font-semibold text-ink">{t.name}</span>
+                    <Mono className="text-ink-3">{t.hours}</Mono>
+                  </motion.span>
+                ))}
+              </motion.div>
+            </div>
+          </motion.div>
+        ))}
+      </div>
+
+      <motion.div
+        variants={fadeUp}
+        className="mt-5 flex items-center justify-between rounded-md bg-ink px-3 py-2.5 text-white"
+      >
+        <div>
+          <Mono className="block text-[9px] tracking-[0.12em] text-tennis-lime">
+            INGESCHREVEN
+          </Mono>
+          <div className="flex items-baseline gap-1.5 text-base font-extrabold text-tennis-lime">
+            <AnimatedNumber value={enrolled} />
+            <span>/ {CAPACITY}</span>
+          </div>
+        </div>
+        <div className="text-right">
+          <Mono className="block text-[9px] tracking-[0.12em] text-white/60">
+            PLEKKEN VRIJ
+          </Mono>
+          <div className="text-base font-extrabold">
+            <AnimatedNumber value={spotsLeft} />
+          </div>
+        </div>
+      </motion.div>
+    </motion.div>
+  );
+}
+
+function AnimatedNumber({ value }: { value: number }) {
+  return (
+    <motion.span
+      key={value}
+      initial={{ opacity: 0, y: -6 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25 }}
+      className="inline-block tabular-nums"
+    >
+      {value}
+    </motion.span>
+  );
+}

--- a/website/components/sections/showcase-row.tsx
+++ b/website/components/sections/showcase-row.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils";
 import { Mono } from "@/components/ui/mono";
 import { ScreenshotFrame } from "@/components/site/screenshot-frame";
 import { AnimatedLessonWeekMock } from "@/components/sections/animated-lesson-week-mock";
+import { AnimatedCampMock } from "@/components/sections/animated-camp-mock";
 import { AnimatedFormBuilderMock } from "@/components/sections/animated-form-builder-mock";
 import { AnimatedEnrollmentMock } from "@/components/sections/animated-enrollment-mock";
 import { AnimatedPlanningMock } from "@/components/sections/animated-planning-mock";
@@ -12,6 +13,7 @@ import type { ShowcaseItem } from "@/content/showcase";
  * frame chrome instead of using the static screenshot/placeholder. */
 const ANIMATED_MOCKS: Record<string, React.ReactNode> = {
   lessenreeksen: <AnimatedLessonWeekMock />,
+  tenniskampen: <AnimatedCampMock />,
   formulierbouwer: <AnimatedFormBuilderMock />,
   "anonieme-inschrijving": <AnimatedEnrollmentMock />,
   planningsalgoritme: <AnimatedPlanningMock />,

--- a/website/content/features.ts
+++ b/website/content/features.ts
@@ -1,5 +1,6 @@
 import {
   CalendarRange,
+  Tent,
   ClipboardList,
   FormInput,
   BrainCircuit,
@@ -19,6 +20,11 @@ export const FEATURES: Feature[] = [
     icon: CalendarRange,
     title: "Lessenreeksen",
     body: "Plan een lessenreeks op jouw maat. Kies je tijdslots, trainers en speelniveau.",
+  },
+  {
+    icon: Tent,
+    title: "Tenniskampen & stages",
+    body: "Organiseer meerdaagse kampen waarvoor spelers zich eenmalig inschrijven. Stel per dag de uren in, wijs trainers toe en laat deelnemers cash of online betalen.",
   },
   {
     icon: ClipboardList,

--- a/website/content/showcase.ts
+++ b/website/content/showcase.ts
@@ -1,5 +1,6 @@
 import {
   CalendarRange,
+  Tent,
   ClipboardList,
   BrainCircuit,
   FormInput,
@@ -51,6 +52,25 @@ export const SHOWCASE: ShowcaseItem[] = [
     image: {
       src: "",
       alt: "CoachOS dashboard met een lessenreeks-overzicht: weken van een seizoen met lessen per dag en capaciteit per groep.",
+      width: 1600,
+      height: 1000,
+    },
+  },
+  {
+    id: "tenniskampen",
+    icon: Tent,
+    kicker: "KAMPEN",
+    heading: "Meerdaagse kampen en stages, zonder gedoe.",
+    body: "Naast lessenreeksen organiseer je ook tenniskampen en stages: een aaneengesloten periode waarvoor spelers zich eenmalig inschrijven. Stel per dag de uren in en wijs trainers toe met hun eigen aanwezigheidsuren.",
+    bullets: [
+      "Een kamp over meerdere dagen, met eigen uren per dag",
+      "Meerdere trainers per kamp, elk met hun eigen uren per dag",
+      "Publieke inschrijving en betaling: cash of online",
+    ],
+    chrome: "dashboard",
+    image: {
+      src: "",
+      alt: "CoachOS dashboard met een tenniskamp: meerdere dagen met kampuren en de toegewezen trainers per dag.",
       width: 1600,
       height: 1000,
     },


### PR DESCRIPTION
## Samenvatting

Toont de nieuwe **Kampen**-module op de marketing-website (`website/`), in dezelfde stijl als de bestaande features.

- **FeatureShowcase** (`content/showcase.ts`): kampen toegevoegd als uitgelichte feature (2e, na lessenreeksen), met een eigen **geanimeerde mock** (`components/sections/animated-camp-mock.tsx`) in dezelfde stijl als de andere mocks: dashboard-chrome van een meerdaags kamp met per-dag trainer-chips (eigen uren) en een live inschrijvingen-teller die naar "vol" loopt. Respecteert `prefers-reduced-motion` + `useInView`.
- **FeatureGrid** (`content/features.ts`): kaartje "Tenniskampen & stages".

## Opmerkingen

- De PR-base is `feat/tenniskampen` (de SaaS-feature-branch, PR #155) zodat de diff alleen de website-wijzigingen bevat. GitHub hertarget deze PR automatisch naar `main` zodra #155 mergt.
- De overige showcase-afbeeldingen zijn nog placeholders; de kampen-rij gebruikt een geanimeerde mock (geen statische afbeelding nodig).
- Prioriteit 2 (kampen-bullets op de club-doelgroep-pagina's + FAQ) is bewust nog niet meegenomen.

## Test Plan

- [x] `bun run build` groen (website)
- [x] Visueel geverifieerd: de kampen-showcase-rij rendert correct en consistent met de bestaande feature-animaties (screenshot)
- [ ] Visuele review door het team

🤖 Generated with [Claude Code](https://claude.com/claude-code)