### PR TITLE
feat(enrollment): mandatory age category + age-aware matching (#98)

### DIFF
--- a/backend/CoachOS.Application/Enrollments/EnrollmentService.cs
+++ b/backend/CoachOS.Application/Enrollments/EnrollmentService.cs
@@ -152,9 +152,15 @@ public class EnrollmentService(
         var order = 0;
         foreach (var dto in request.Fields)
         {
-            var optionsJson = dto.Type == (int)FormFieldType.MultipleChoice && dto.Options?.Count > 0
+            // MultipleChoice and AgeCategory both store their choices in Options.
+            var storesOptions = dto.Type == (int)FormFieldType.MultipleChoice
+                || dto.Type == (int)FormFieldType.AgeCategory;
+            var optionsJson = storesOptions && dto.Options?.Count > 0
                 ? JsonSerializer.Serialize(dto.Options)
                 : null;
+
+            // The age-category question is always mandatory, regardless of what the admin toggled.
+            var isRequired = dto.Type == (int)FormFieldType.AgeCategory || dto.IsRequired;
 
             if (dto.Id.HasValue)
             {
@@ -163,7 +169,7 @@ public class EnrollmentService(
                 {
                     existing.Label = dto.Label;
                     existing.Type = (FormFieldType)dto.Type;
-                    existing.IsRequired = dto.IsRequired;
+                    existing.IsRequired = isRequired;
                     existing.Order = order;
                     existing.Options = optionsJson;
                 }
@@ -175,7 +181,7 @@ public class EnrollmentService(
                     EnrollmentFormId = form.Id,
                     Label = dto.Label,
                     Type = (FormFieldType)dto.Type,
-                    IsRequired = dto.IsRequired,
+                    IsRequired = isRequired,
                     Order = order,
                     Options = optionsJson,
                 };

--- a/backend/CoachOS.Application/Enrollments/Validators/SaveEnrollmentFormRequestValidator.cs
+++ b/backend/CoachOS.Application/Enrollments/Validators/SaveEnrollmentFormRequestValidator.cs
@@ -17,6 +17,17 @@ public class SaveEnrollmentFormRequestValidator : AbstractValidator<SaveEnrollme
             field.RuleFor(f => f.Type)
                 .Must(t => Enum.IsDefined(typeof(FormFieldType), t))
                 .WithMessage("Ongeldig veldtype");
+
+            // An age-category field needs at least two buckets to group students by.
+            field.RuleFor(f => f.Options)
+                .Must(o => o is not null && o.Count(s => !string.IsNullOrWhiteSpace(s)) >= 2)
+                .When(f => f.Type == (int)FormFieldType.AgeCategory)
+                .WithMessage("Een leeftijdscategorie heeft minstens twee opties nodig");
         });
+
+        // At most one age-category question per form, otherwise the algorithm can't tell which to group on.
+        RuleFor(x => x.Fields)
+            .Must(fields => fields.Count(f => f.Type == (int)FormFieldType.AgeCategory) <= 1)
+            .WithMessage("Er kan maar één leeftijdscategorie-veld zijn");
     }
 }

--- a/backend/CoachOS.Application/Planning/PlanningProposalBuilder.cs
+++ b/backend/CoachOS.Application/Planning/PlanningProposalBuilder.cs
@@ -68,7 +68,8 @@ internal static class PlanningProposalBuilder
                 StudentNames: memberEnrollments.Select(e => e.StudentName).ToList(),
                 Size: memberEnrollments.Count,
                 IsOpenToGrouping: leaderEnrollment?.IsOpenToGrouping ?? false,
-                Preferences: groupPrefs));
+                Preferences: groupPrefs,
+                AgeCategory: GetSharedAgeCategory(memberEnrollments)));
 
             foreach (var e in memberEnrollments)
                 groupedEnrollmentIds.Add(e.Id);
@@ -86,7 +87,8 @@ internal static class PlanningProposalBuilder
                 StudentNames: [enrollment.StudentName],
                 Size: 1,
                 IsOpenToGrouping: enrollment.IsOpenToGrouping,
-                Preferences: prefs));
+                Preferences: prefs,
+                AgeCategory: GetAgeCategory(enrollment)));
         }
 
         return (units, groupedEnrollmentIds);
@@ -142,6 +144,32 @@ internal static class PlanningProposalBuilder
         }
 
         return conflicts;
+    }
+
+    /// <summary>
+    /// The age-category bucket a student chose on the enrollment form, or null when the form
+    /// has no age-category field (or it was left unanswered). The matching algorithm treats
+    /// null as unconstrained.
+    /// </summary>
+    private static string? GetAgeCategory(Enrollment enrollment)
+        => enrollment.FormResponses
+            .FirstOrDefault(r => r.FormField?.Type == FormFieldType.AgeCategory)
+            ?.Value;
+
+    /// <summary>
+    /// The shared age bucket of a pre-formed group: the single bucket if every member agrees,
+    /// otherwise null. A mixed-age group is the user's explicit choice, so it stays unconstrained
+    /// rather than blocking the group.
+    /// </summary>
+    private static string? GetSharedAgeCategory(List<Enrollment> members)
+    {
+        var buckets = members
+            .Select(GetAgeCategory)
+            .Where(c => !string.IsNullOrEmpty(c))
+            .Distinct()
+            .ToList();
+
+        return buckets.Count == 1 ? buckets[0] : null;
     }
 
     private static Dictionary<Guid, SlotPreference> IntersectPreferences(

--- a/backend/CoachOS.Application/Planning/SchedulingAlgorithm.cs
+++ b/backend/CoachOS.Application/Planning/SchedulingAlgorithm.cs
@@ -17,6 +17,11 @@ public static class SchedulingAlgorithm
         Dictionary<Guid, int> slotUsed = input.Slots.ToDictionary(s => s.WeeklyTemplateEntryId, _ => 0);
         // Track which slots have assignments and whether they are open to merging
         Dictionary<Guid, bool> slotIsOpenToMerging = new();
+        // Track the age category a slot is locked to. A slot becomes locked the first time an
+        // age-bearing unit is placed in it; afterwards only units of the same bucket (or units
+        // with no age category) may be auto-grouped into it. Slots absent from this map, or
+        // mapped to null, are unconstrained.
+        Dictionary<Guid, string?> slotAgeCategory = new();
         HashSet<Guid> assigned = new(); // unit IDs that have been assigned
 
         List<EnrollmentUnit> groups = input.Units.Where(u => u.IsGroup).ToList();
@@ -31,6 +36,7 @@ public static class SchedulingAlgorithm
                 assignments.Add(new ProposedAssignment(bestSlot.Value, group.GroupId, null, group.Size));
                 slotUsed[bestSlot.Value] += group.Size;
                 slotIsOpenToMerging[bestSlot.Value] = false;
+                LockSlotAge(slotAgeCategory, bestSlot.Value, group.AgeCategory);
                 assigned.Add(group.Id);
             }
         }
@@ -38,12 +44,13 @@ public static class SchedulingAlgorithm
         // Step 2: Lock pre-formed groups that ARE open to grouping
         foreach (EnrollmentUnit group in groups.Where(g => g.IsOpenToGrouping && !assigned.Contains(g.Id)))
         {
-            Guid? bestSlot = GetBestViableSlot(group, slotCapacity, slotUsed);
+            Guid? bestSlot = GetBestViableSlot(group, slotCapacity, slotUsed, slotAgeCategory);
             if (bestSlot.HasValue)
             {
                 assignments.Add(new ProposedAssignment(bestSlot.Value, group.GroupId, null, group.Size));
                 slotUsed[bestSlot.Value] += group.Size;
                 slotIsOpenToMerging[bestSlot.Value] = true;
+                LockSlotAge(slotAgeCategory, bestSlot.Value, group.AgeCategory);
                 assigned.Add(group.Id);
             }
         }
@@ -66,7 +73,8 @@ public static class SchedulingAlgorithm
                 List<EnrollmentUnit> candidates = unassignedSolos
                     .Where(u => !assigned.Contains(u.Id)
                         && u.Preferences.TryGetValue(slotId, out SlotPreference pref)
-                        && pref != SlotPreference.Unavailable)
+                        && pref != SlotPreference.Unavailable
+                        && CanShareSlot(slotAgeCategory, slotId, u.AgeCategory))
                     .ToList();
 
                 if (candidates.Count == 1 && candidates[0].Size <= remaining)
@@ -74,6 +82,7 @@ public static class SchedulingAlgorithm
                     EnrollmentUnit unit = candidates[0];
                     assignments.Add(new ProposedAssignment(slotId, null, unit.EnrollmentIds[0], unit.Size));
                     slotUsed[slotId] += unit.Size;
+                    LockSlotAge(slotAgeCategory, slotId, unit.AgeCategory);
                     assigned.Add(unit.Id);
                     changed = true;
                 }
@@ -87,7 +96,7 @@ public static class SchedulingAlgorithm
 
         if (openUnits.Count >= 2)
         {
-            List<(Guid SlotId, List<EnrollmentUnit> Members)> autoMerged = AutoMergeUnits(openUnits, slotCapacity, slotUsed, slotIsOpenToMerging);
+            List<(Guid SlotId, List<EnrollmentUnit> Members)> autoMerged = AutoMergeUnits(openUnits, slotCapacity, slotUsed, slotIsOpenToMerging, slotAgeCategory);
             foreach ((Guid slotId, List<EnrollmentUnit> members) in autoMerged)
             {
                 foreach (EnrollmentUnit member in members)
@@ -110,13 +119,14 @@ public static class SchedulingAlgorithm
         List<EnrollmentUnit> remainingSolos = unassignedSolos.Where(u => !assigned.Contains(u.Id)).ToList();
         foreach (EnrollmentUnit unit in remainingSolos)
         {
-            Guid? bestSlot = GetBestViableSlot(unit, slotCapacity, slotUsed);
+            Guid? bestSlot = GetBestViableSlot(unit, slotCapacity, slotUsed, slotAgeCategory);
             if (bestSlot.HasValue)
             {
                 // Check if this slot already has assignments that are open to merging
                 bool isMerging = slotIsOpenToMerging.TryGetValue(bestSlot.Value, out bool open) && open && slotUsed[bestSlot.Value] > 0;
                 assignments.Add(new ProposedAssignment(bestSlot.Value, null, unit.EnrollmentIds[0], unit.Size, IsAutoMerged: isMerging));
                 slotUsed[bestSlot.Value] += unit.Size;
+                LockSlotAge(slotAgeCategory, bestSlot.Value, unit.AgeCategory);
                 assigned.Add(unit.Id);
             }
         }
@@ -165,16 +175,39 @@ public static class SchedulingAlgorithm
     private static Guid? GetBestViableSlot(
         EnrollmentUnit unit,
         Dictionary<Guid, int> slotCapacity,
-        Dictionary<Guid, int> slotUsed)
+        Dictionary<Guid, int> slotUsed,
+        Dictionary<Guid, string?> slotAgeCategory)
     {
         return unit.Preferences
             .Where(p => p.Value != SlotPreference.Unavailable
                 && slotCapacity.ContainsKey(p.Key)
-                && slotCapacity[p.Key] - slotUsed[p.Key] >= unit.Size)
+                && slotCapacity[p.Key] - slotUsed[p.Key] >= unit.Size
+                && CanShareSlot(slotAgeCategory, p.Key, unit.AgeCategory))
             .OrderByDescending(p => p.Value)
             .ThenBy(p => slotUsed[p.Key])
             .Select(p => (Guid?)p.Key)
             .FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Whether a unit may join a slot given age-category locking. A unit with no age category is
+    /// unconstrained; an unlocked slot (absent or null) accepts anyone; otherwise buckets must match.
+    /// </summary>
+    private static bool CanShareSlot(Dictionary<Guid, string?> slotAgeCategory, Guid slotId, string? unitAge)
+        => unitAge is null
+            || !slotAgeCategory.TryGetValue(slotId, out string? locked)
+            || locked is null
+            || locked == unitAge;
+
+    /// <summary>
+    /// Lock a slot to a unit's age bucket on first placement. No-op for units without an age
+    /// category or slots already locked to a (non-null) bucket.
+    /// </summary>
+    private static void LockSlotAge(Dictionary<Guid, string?> slotAgeCategory, Guid slotId, string? unitAge)
+    {
+        if (unitAge is null) return;
+        if (!slotAgeCategory.TryGetValue(slotId, out string? locked) || locked is null)
+            slotAgeCategory[slotId] = unitAge;
     }
 
     /// <summary>
@@ -184,7 +217,8 @@ public static class SchedulingAlgorithm
         List<EnrollmentUnit> openUnits,
         Dictionary<Guid, int> slotCapacity,
         Dictionary<Guid, int> slotUsed,
-        Dictionary<Guid, bool> slotIsOpenToMerging)
+        Dictionary<Guid, bool> slotIsOpenToMerging,
+        Dictionary<Guid, string?> slotAgeCategory)
     {
         List<(Guid, List<EnrollmentUnit>)> result = new();
         HashSet<Guid> used = new();
@@ -202,13 +236,29 @@ public static class SchedulingAlgorithm
                 .Where(u => !used.Contains(u.Id)
                     && u.Size <= remaining
                     && u.Preferences.TryGetValue(slotId, out SlotPreference pref)
-                    && pref == SlotPreference.Preferred)
+                    && pref == SlotPreference.Preferred
+                    && CanShareSlot(slotAgeCategory, slotId, u.AgeCategory))
                 .ToList();
 
-            // Greedily pack candidates into the slot
+            // A slot can only hold one age bucket. If already locked, keep that bucket; otherwise
+            // pick the most-represented bucket among candidates so we merge as many as possible.
+            // Units without an age category are compatible with whatever bucket the slot settles on.
+            string? targetBucket = slotAgeCategory.GetValueOrDefault(slotId);
+            targetBucket ??= candidates
+                .Where(c => c.AgeCategory is not null)
+                .GroupBy(c => c.AgeCategory)
+                .OrderByDescending(g => g.Count())
+                .Select(g => g.Key)
+                .FirstOrDefault();
+
+            List<EnrollmentUnit> eligible = targetBucket is null
+                ? candidates
+                : candidates.Where(c => c.AgeCategory == targetBucket || c.AgeCategory is null).ToList();
+
+            // Greedily pack eligible candidates into the slot
             List<EnrollmentUnit> selected = new();
             int filled = 0;
-            foreach (EnrollmentUnit candidate in candidates)
+            foreach (EnrollmentUnit candidate in eligible)
             {
                 if (filled + candidate.Size <= remaining)
                 {
@@ -220,6 +270,7 @@ public static class SchedulingAlgorithm
             if (selected.Count >= 2 || (selected.Count >= 1 && slotUsed[slotId] > 0))
             {
                 result.Add((slotId, selected));
+                LockSlotAge(slotAgeCategory, slotId, targetBucket);
                 foreach (EnrollmentUnit c in selected)
                     used.Add(c.Id);
             }

--- a/backend/CoachOS.Application/Planning/SchedulingModels.cs
+++ b/backend/CoachOS.Application/Planning/SchedulingModels.cs
@@ -14,7 +14,8 @@ public record EnrollmentUnit(
     List<string> StudentNames,
     int Size,
     bool IsOpenToGrouping,
-    Dictionary<Guid, SlotPreference> Preferences);
+    Dictionary<Guid, SlotPreference> Preferences,
+    string? AgeCategory = null);
 
 public record SlotInfo(
     Guid WeeklyTemplateEntryId,

--- a/backend/CoachOS.Domain/Enums/FormFieldType.cs
+++ b/backend/CoachOS.Domain/Enums/FormFieldType.cs
@@ -4,5 +4,6 @@ public enum FormFieldType
 {
     Text = 1,
     MultipleChoice = 2,
-    YesNo = 3
+    YesNo = 3,
+    AgeCategory = 4
 }

--- a/backend/CoachOS.Tests/Services/SchedulingAlgorithmTests.cs
+++ b/backend/CoachOS.Tests/Services/SchedulingAlgorithmTests.cs
@@ -299,12 +299,128 @@ public class SchedulingAlgorithmTests
         result.Conflicts.Should().HaveCount(1);
     }
 
+    // ── Age category matching ────────────────────────────────────────────────
+
+    [Test]
+    public void Generate_OpenSolosSameAge_AutoMergedTogether()
+    {
+        var alice = MakeSolo("Alice", new() { { Slot1, SlotPreference.Preferred } }, isOpenToGrouping: true, ageCategory: "7-9");
+        var bob = MakeSolo("Bob", new() { { Slot1, SlotPreference.Preferred } }, isOpenToGrouping: true, ageCategory: "7-9");
+
+        var input = new SchedulingInput(
+            [alice, bob],
+            [new SlotInfo(Slot1, 4)]);
+
+        var result = Generate(input);
+
+        result.Assignments.Should().HaveCount(2);
+        result.Assignments.Should().AllSatisfy(a => a.WeeklyTemplateEntryId.Should().Be(Slot1));
+        result.Conflicts.Should().BeEmpty();
+    }
+
+    [Test]
+    public void Generate_OpenSolosDifferentAge_NotMergedIntoSameSlot()
+    {
+        // Only one slot, both prefer it, but different age buckets must not share it.
+        var young = MakeSolo("Young", new() { { Slot1, SlotPreference.Preferred } }, isOpenToGrouping: true, ageCategory: "4-6");
+        var older = MakeSolo("Older", new() { { Slot1, SlotPreference.Preferred } }, isOpenToGrouping: true, ageCategory: "9-11");
+
+        var input = new SchedulingInput(
+            [young, older],
+            [new SlotInfo(Slot1, 4)]);
+
+        var result = Generate(input);
+
+        // One claims the slot (locking its bucket); the other has nowhere age-compatible to go.
+        result.Assignments.Should().HaveCount(1);
+        result.Conflicts.Should().HaveCount(1);
+        var assignedSlot = result.Assignments[0].WeeklyTemplateEntryId;
+        assignedSlot.Should().Be(Slot1);
+    }
+
+    [Test]
+    public void Generate_ThreeOpenSolos_SameAgeMerge_OtherAgeSeparated()
+    {
+        // Two "4-6" and one "9-11", two roomy slots, everyone prefers both.
+        var a = MakeSolo("A", new() { { Slot1, SlotPreference.Preferred }, { Slot2, SlotPreference.Preferred } }, isOpenToGrouping: true, ageCategory: "4-6");
+        var b = MakeSolo("B", new() { { Slot1, SlotPreference.Preferred }, { Slot2, SlotPreference.Preferred } }, isOpenToGrouping: true, ageCategory: "4-6");
+        var c = MakeSolo("C", new() { { Slot1, SlotPreference.Preferred }, { Slot2, SlotPreference.Preferred } }, isOpenToGrouping: true, ageCategory: "9-11");
+
+        var input = new SchedulingInput(
+            [a, b, c],
+            [new SlotInfo(Slot1, 4), new SlotInfo(Slot2, 4)]);
+
+        var result = Generate(input);
+
+        result.Assignments.Should().HaveCount(3);
+        result.Conflicts.Should().BeEmpty();
+
+        var slotOf = result.Assignments.ToDictionary(x => x.EnrollmentId!.Value, x => x.WeeklyTemplateEntryId);
+        slotOf[a.EnrollmentIds[0]].Should().Be(slotOf[b.EnrollmentIds[0]]); // same-age together
+        slotOf[c.EnrollmentIds[0]].Should().NotBe(slotOf[a.EnrollmentIds[0]]); // other age elsewhere
+    }
+
+    [Test]
+    public void Generate_SoloDifferentAgeThanGroup_NotMergedIn()
+    {
+        // Open group of "4-6" claims the only slot; a "9-11" solo must not be merged in.
+        var group = MakeGroup("Kids", 2, new() { { Slot1, SlotPreference.Preferred } }, isOpenToGrouping: true, ageCategory: "4-6");
+        var solo = MakeSolo("Teen", new() { { Slot1, SlotPreference.Preferred } }, isOpenToGrouping: true, ageCategory: "9-11");
+
+        var input = new SchedulingInput(
+            [group, solo],
+            [new SlotInfo(Slot1, 4)]);
+
+        var result = Generate(input);
+
+        result.Assignments.Should().HaveCount(1);
+        result.Assignments[0].GroupId.Should().NotBeNull();
+        result.Conflicts.Should().HaveCount(1);
+        result.Conflicts[0].StudentName.Should().Be("Teen");
+    }
+
+    [Test]
+    public void Generate_SoloSameAgeAsGroup_MergedIn()
+    {
+        var group = MakeGroup("Kids", 2, new() { { Slot1, SlotPreference.Preferred } }, isOpenToGrouping: true, ageCategory: "4-6");
+        var solo = MakeSolo("AlsoKid", new() { { Slot1, SlotPreference.Preferred } }, isOpenToGrouping: true, ageCategory: "4-6");
+
+        var input = new SchedulingInput(
+            [group, solo],
+            [new SlotInfo(Slot1, 4)]);
+
+        var result = Generate(input);
+
+        result.Assignments.Should().HaveCount(2);
+        result.Assignments.Should().AllSatisfy(a => a.WeeklyTemplateEntryId.Should().Be(Slot1));
+        result.Conflicts.Should().BeEmpty();
+    }
+
+    [Test]
+    public void Generate_NoAgeCategory_AutoMergesAsBefore()
+    {
+        // Feature unused: null age buckets must not constrain anything.
+        var alice = MakeSolo("Alice", new() { { Slot1, SlotPreference.Preferred } }, isOpenToGrouping: true);
+        var bob = MakeSolo("Bob", new() { { Slot1, SlotPreference.Preferred } }, isOpenToGrouping: true);
+
+        var input = new SchedulingInput(
+            [alice, bob],
+            [new SlotInfo(Slot1, 4)]);
+
+        var result = Generate(input);
+
+        result.Assignments.Should().HaveCount(2);
+        result.Assignments.Should().AllSatisfy(a => a.WeeklyTemplateEntryId.Should().Be(Slot1));
+        result.Conflicts.Should().BeEmpty();
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     private static EnrollmentUnit MakeSolo(
         string name,
         Dictionary<Guid, SlotPreference> prefs,
-        bool isOpenToGrouping = false)
+        bool isOpenToGrouping = false,
+        string? ageCategory = null)
     {
         var id = Guid.NewGuid();
         return new EnrollmentUnit(
@@ -315,13 +431,16 @@ public class SchedulingAlgorithmTests
             StudentNames: [name],
             Size: 1,
             IsOpenToGrouping: isOpenToGrouping,
-            Preferences: prefs);
+            Preferences: prefs,
+            AgeCategory: ageCategory);
     }
 
     private static EnrollmentUnit MakeGroup(
         string name,
         int size,
-        Dictionary<Guid, SlotPreference> prefs)
+        Dictionary<Guid, SlotPreference> prefs,
+        bool isOpenToGrouping = false,
+        string? ageCategory = null)
     {
         var groupId = Guid.NewGuid();
         var enrollmentIds = Enumerable.Range(0, size).Select(_ => Guid.NewGuid()).ToList();
@@ -333,7 +452,8 @@ public class SchedulingAlgorithmTests
             EnrollmentIds: enrollmentIds,
             StudentNames: names,
             Size: size,
-            IsOpenToGrouping: false,
-            Preferences: prefs);
+            IsOpenToGrouping: isOpenToGrouping,
+            Preferences: prefs,
+            AgeCategory: ageCategory);
     }
 }

--- a/backend/CoachOS.Tests/Validators/SaveEnrollmentFormRequestValidatorTests.cs
+++ b/backend/CoachOS.Tests/Validators/SaveEnrollmentFormRequestValidatorTests.cs
@@ -1,0 +1,93 @@
+using CoachOS.Application.Enrollments.DTOs;
+using CoachOS.Application.Enrollments.Validators;
+using CoachOS.Domain.Enums;
+using FluentAssertions;
+using FluentValidation.Results;
+using NUnit.Framework;
+
+namespace CoachOS.Tests.Validators;
+
+[TestFixture]
+public class SaveEnrollmentFormRequestValidatorTests
+{
+    private SaveEnrollmentFormRequestValidator _validator = null!;
+
+    [SetUp]
+    public void SetUp() => _validator = new SaveEnrollmentFormRequestValidator();
+
+    private static SaveFormFieldRequest AgeField(List<string>? options) => new()
+    {
+        Label = "Leeftijdscategorie",
+        Type = (int)FormFieldType.AgeCategory,
+        Order = 0,
+        Options = options,
+    };
+
+    [Test]
+    public void Validate_SingleAgeFieldWithTwoOptions_Passes()
+    {
+        var request = new SaveEnrollmentFormRequest
+        {
+            Fields = [AgeField(["4-6", "7-9"])],
+        };
+
+        ValidationResult result = _validator.Validate(request);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Test]
+    public void Validate_AgeFieldWithOneOption_Fails()
+    {
+        var request = new SaveEnrollmentFormRequest
+        {
+            Fields = [AgeField(["4-6"])],
+        };
+
+        ValidationResult result = _validator.Validate(request);
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Test]
+    public void Validate_AgeFieldWithNoOptions_Fails()
+    {
+        var request = new SaveEnrollmentFormRequest
+        {
+            Fields = [AgeField(null)],
+        };
+
+        ValidationResult result = _validator.Validate(request);
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Test]
+    public void Validate_TwoAgeFields_Fails()
+    {
+        var request = new SaveEnrollmentFormRequest
+        {
+            Fields = [AgeField(["4-6", "7-9"]), AgeField(["10-12", "13-15"])],
+        };
+
+        ValidationResult result = _validator.Validate(request);
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Test]
+    public void Validate_FormWithoutAgeField_Passes()
+    {
+        var request = new SaveEnrollmentFormRequest
+        {
+            Fields =
+            [
+                new() { Label = "Naam ouder", Type = (int)FormFieldType.Text, Order = 0 },
+            ],
+        };
+
+        ValidationResult result = _validator.Validate(request);
+
+        result.IsValid.Should().BeTrue();
+    }
+}

--- a/backend/Scripts/seed-data.json
+++ b/backend/Scripts/seed-data.json
@@ -128,13 +128,14 @@
       { "dayOfWeek": 5, "startTime": "10:00", "endTime": "11:00", "courtName": "Baan 1", "maxStudents": 4 },
       { "dayOfWeek": 5, "startTime": "10:00", "endTime": "11:00", "courtName": "Baan 2", "maxStudents": 4 },
       { "dayOfWeek": 5, "startTime": "11:00", "endTime": "12:00", "courtName": "Baan 1", "maxStudents": 4 }
-    ]
+    ],
+    "ageCategoryOptions": ["8-10 jaar", "11-13 jaar", "14-17 jaar", "Volwassenen"]
   },
   "planningEnrollments": [
     {
       "label": "Family De Boer (group of 3, Wed afternoon, open to merge)",
       "studentName": "Sofie De Boer", "studentEmail": "sofie.deboer@gmail.com", "studentPhone": "+32478112233",
-      "enrollmentType": "group", "isOpenToGrouping": true,
+      "enrollmentType": "group", "isOpenToGrouping": true, "ageCategory": "8-10 jaar",
       "groupMembers": [
         { "studentName": "Fien De Boer", "studentEmail": "sofie.deboer+fien@gmail.com", "studentPhone": null },
         { "studentName": "Stan De Boer", "studentEmail": "sofie.deboer+stan@gmail.com", "studentPhone": null }
@@ -144,7 +145,7 @@
     {
       "label": "Couple Peeters-Janssens (group of 2, evenings only, exclusive)",
       "studentName": "Bart Peeters", "studentEmail": "bart.peeters@outlook.be", "studentPhone": "+32479223344",
-      "enrollmentType": "group", "isOpenToGrouping": false,
+      "enrollmentType": "group", "isOpenToGrouping": false, "ageCategory": "Volwassenen",
       "groupMembers": [
         { "studentName": "Lisa Janssens", "studentEmail": "lisa.janssens@outlook.be", "studentPhone": "+32479223345" }
       ],
@@ -153,55 +154,55 @@
     {
       "label": "Emma Van Acker (solo, open, Wed+Sat)",
       "studentName": "Emma Van Acker", "studentEmail": "emma.vanacker@student.be", "studentPhone": "+32468001122",
-      "enrollmentType": "solo", "isOpenToGrouping": true,
+      "enrollmentType": "solo", "isOpenToGrouping": true, "ageCategory": "14-17 jaar",
       "slotPreferences": [1, 1, 3, 2, 2, 2, 3, 3, 2, 2, 1]
     },
     {
       "label": "Thomas Wouters (solo, open, Wed+Sat — auto-merge candidate)",
       "studentName": "Thomas Wouters", "studentEmail": "thomas.w@student.be", "studentPhone": "+32468003344",
-      "enrollmentType": "solo", "isOpenToGrouping": true,
+      "enrollmentType": "solo", "isOpenToGrouping": true, "ageCategory": "14-17 jaar",
       "slotPreferences": [3, 3, 3, 2, 2, 1, 3, 3, 2, 1, 2]
     },
     {
       "label": "Noor Hendrickx (solo, open, Tue+Thu evenings)",
       "studentName": "Noor Hendrickx", "studentEmail": "noor.h@telenet.be", "studentPhone": "+32473556677",
-      "enrollmentType": "solo", "isOpenToGrouping": true,
+      "enrollmentType": "solo", "isOpenToGrouping": true, "ageCategory": "Volwassenen",
       "slotPreferences": [2, 1, 2, 3, 3, 3, 2, 1, 3, 3, 3]
     },
     {
       "label": "Pieter Vermeersch (solo, open, flexible retiree)",
       "studentName": "Pieter Vermeersch", "studentEmail": "pieter.verm@skynet.be", "studentPhone": "+32475889900",
-      "enrollmentType": "solo", "isOpenToGrouping": true,
+      "enrollmentType": "solo", "isOpenToGrouping": true, "ageCategory": "Volwassenen",
       "slotPreferences": [1, 1, 1, 2, 2, 1, 1, 1, 2, 2, 1]
     },
     {
       "label": "Sarah Dubois (solo, exclusive, Thu+Sat only — low overlap)",
       "studentName": "Sarah Dubois", "studentEmail": "sarah.dubois@uzleuven.be", "studentPhone": "+32471990011",
-      "enrollmentType": "solo", "isOpenToGrouping": false,
+      "enrollmentType": "solo", "isOpenToGrouping": false, "ageCategory": "Volwassenen",
       "slotPreferences": [3, 3, 3, 3, 3, 3, 2, 1, 2, 1, 1]
     },
     {
       "label": "Kevin Goossens (solo, open, Tue evenings — auto-merge candidate with Noor)",
       "studentName": "Kevin Goossens", "studentEmail": "kevin.g@proximus.be", "studentPhone": "+32476001122",
-      "enrollmentType": "solo", "isOpenToGrouping": true,
+      "enrollmentType": "solo", "isOpenToGrouping": true, "ageCategory": "Volwassenen",
       "slotPreferences": [1, 1, 2, 3, 3, 3, 2, 3, 3, 3, 3]
     },
     {
       "label": "Ines Claes (solo, open, Sat morning)",
       "studentName": "Ines Claes", "studentEmail": "ines.claes@hotmail.com", "studentPhone": "+32479112233",
-      "enrollmentType": "solo", "isOpenToGrouping": true,
+      "enrollmentType": "solo", "isOpenToGrouping": true, "ageCategory": "11-13 jaar",
       "slotPreferences": [3, 3, 3, 3, 3, 3, 3, 3, 1, 1, 2]
     },
     {
       "label": "Jules Van Damme (solo, open, Saturday only)",
       "studentName": "Jules Van Damme", "studentEmail": "jules.vd@gmail.com", "studentPhone": "+32478334455",
-      "enrollmentType": "solo", "isOpenToGrouping": true,
+      "enrollmentType": "solo", "isOpenToGrouping": true, "ageCategory": "14-17 jaar",
       "slotPreferences": [3, 3, 3, 3, 3, 3, 3, 3, 2, 2, 2]
     },
     {
       "label": "Marie-Claire Vos (solo, open, Tue evening — auto-merge candidate)",
       "studentName": "Marie-Claire Vos", "studentEmail": "mc.vos@gmail.com", "studentPhone": "+32474556677",
-      "enrollmentType": "solo", "isOpenToGrouping": true,
+      "enrollmentType": "solo", "isOpenToGrouping": true, "ageCategory": "Volwassenen",
       "slotPreferences": [2, 2, 1, 3, 3, 3, 1, 3, 3, 3, 3]
     }
   ],

--- a/backend/Scripts/seed-demo-data.py
+++ b/backend/Scripts/seed-demo-data.py
@@ -357,6 +357,36 @@ def create_planning_series(api: ApiClient, spec: dict, club_ids: list[str],
     return sid
 
 
+def setup_planning_form(api: ApiClient, planning_series_id: str,
+                        options: list[str]) -> str | None:
+    """Adds a mandatory age-category question to the planning series so the
+    age-aware matching path is exercised end to end. Returns the field id so
+    enrollments can answer it (the question is required, so they must)."""
+    print("\n7b. Adding age-category question to planning series...")
+    saved = api.put(
+        f"/lessonseries/{planning_series_id}/form",
+        {"fields": [
+            {"label": "Leeftijdscategorie", "type": 4, "isRequired": True,
+             "order": 0, "options": options},
+        ]},
+    )
+    if saved is None:
+        print("   WARNING: could not set planning form (see stderr).",
+              file=sys.stderr)
+        return None
+
+    form = api.get(f"/public/lessonseries/{planning_series_id}/form", auth=False)
+    field_id = next(
+        (f["id"] for f in (form or {}).get("fields", []) if f.get("type") == 4),
+        None)
+    if field_id is None:
+        print("   WARNING: age-category field not found after save.",
+              file=sys.stderr)
+    else:
+        print(f"   Age-category question added ({len(options)} buckets)")
+    return field_id
+
+
 def setup_second_org(api_base: str, cfg: dict) -> None:
     """Registreert een tweede organisatie met eigen admin en nodigt de eerste
     admin uit als trainer in die nieuwe org. Omdat die user al globaal actief
@@ -406,7 +436,8 @@ def generate_and_confirm_planning(api: ApiClient, planning_series_id: str) -> No
 
 
 def planning_enrollments(api: ApiClient, planning_series_id: str,
-                         enrollments: list[dict]) -> None:
+                         enrollments: list[dict],
+                         age_field_id: str | None = None) -> None:
     print("   Fetching time slots...")
     slots = api.get(f"/public/lessonseries/{planning_series_id}/timeslots",
                     auth=False) or []
@@ -422,6 +453,13 @@ def planning_enrollments(api: ApiClient, planning_series_id: str,
             for i, pref in enumerate(prefs)
             if i < len(slot_ids)
         ]
+        # The age-category question is mandatory once configured, so every
+        # enrollment (and group member) must answer it.
+        def age_responses(spec: dict) -> list[dict]:
+            if age_field_id and spec.get("ageCategory"):
+                return [{"formFieldId": age_field_id, "value": spec["ageCategory"]}]
+            return []
+
         body = {
             "studentName":  e["studentName"],
             "studentEmail": e["studentEmail"],
@@ -429,11 +467,11 @@ def planning_enrollments(api: ApiClient, planning_series_id: str,
             "enrollmentType": e.get("enrollmentType", "solo"),
             "isOpenToGrouping": e.get("isOpenToGrouping", False),
             "timeSlotPreferences": time_slot_prefs,
-            "responses": [],
+            "responses": age_responses(e),
         }
         if e.get("groupMembers"):
             body["groupMembers"] = [
-                {**m, "responses": []} for m in e["groupMembers"]
+                {**m, "responses": age_responses(e)} for m in e["groupMembers"]
             ]
         result = api.post(f"/public/lessonseries/{planning_series_id}/enroll",
                           body, auth=False)
@@ -612,7 +650,11 @@ def main() -> int:
     planning_id = create_planning_series(
         api, data["planningSeries"], club_ids, trainer_id, today, deadline_iso)
     if planning_id:
-        planning_enrollments(api, planning_id, data["planningEnrollments"])
+        age_options = data["planningSeries"].get("ageCategoryOptions", [])
+        age_field_id = (setup_planning_form(api, planning_id, age_options)
+                        if age_options else None)
+        planning_enrollments(api, planning_id, data["planningEnrollments"],
+                             age_field_id)
         generate_and_confirm_planning(api, planning_id)
 
     create_standalone_lessons(

--- a/frontend/app/(dashboard)/dashboard/lessons/[id]/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/lessons/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { use, useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useForm, Controller } from "react-hook-form";
@@ -934,11 +935,11 @@ function LessonWeekView({
 // ─── Form Builder Section ─────────────────────────────────────────────────────
 
 const FIELD_TYPES = [
-  { value: 1, label: "Vrije tekst" },
-  { value: 2, label: "Meerkeuze" },
-  { value: 3, label: "Ja/Nee" },
-  { value: 4, label: "Leeftijdscategorie" },
-];
+  { value: 1, labelKey: "type_text" },
+  { value: 2, labelKey: "type_multiple_choice" },
+  { value: 3, labelKey: "type_yes_no" },
+  { value: 4, labelKey: "type_age_category" },
+] as const;
 
 // Field types that carry a list of choices stored in `options`.
 const OPTION_FIELD_TYPES = [2, 4];
@@ -948,6 +949,7 @@ interface DraftField extends SaveFormFieldRequest {
 }
 
 function FormBuilderSection({ seriesId }: { seriesId: string }) {
+  const t = useTranslations("formBuilder");
   const queryClient = useQueryClient();
   const [fields, setFields] = useState<DraftField[]>([]);
   const [loaded, setLoaded] = useState(false);
@@ -1069,7 +1071,7 @@ function FormBuilderSection({ seriesId }: { seriesId: string }) {
           <ClipboardList size={13} className="text-tennis-green" />
         </div>
         <h2 className="text-sm font-semibold text-gray-800">
-          Inschrijfformulier
+          {t("title")}
         </h2>
       </div>
 
@@ -1077,15 +1079,15 @@ function FormBuilderSection({ seriesId }: { seriesId: string }) {
         {/* Predefined fields badge list */}
         <div>
           <p className="text-xs text-gray-400 mb-2">
-            Vaste velden (altijd zichtbaar)
+            {t("predefined_fields_hint")}
           </p>
           <div className="flex flex-wrap gap-2">
             {[
-              "Voornaam",
-              "Achternaam",
-              "E-mailadres",
-              "Inschrijvingstype",
-              "Beschikbaarheid",
+              t("pf_firstname"),
+              t("pf_lastname"),
+              t("pf_email"),
+              t("pf_enrollment_type"),
+              t("pf_availability"),
             ].map((f) => (
               <span
                 key={f}
@@ -1099,10 +1101,7 @@ function FormBuilderSection({ seriesId }: { seriesId: string }) {
 
         {/* Custom fields */}
         {fields.length === 0 && (
-          <p className="text-xs text-gray-400 py-2">
-            Nog geen aangepaste velden. Klik &apos;Veld toevoegen&apos; om te
-            beginnen.
-          </p>
+          <p className="text-xs text-gray-400 py-2">{t("no_fields")}</p>
         )}
 
         <div className="space-y-3">
@@ -1114,7 +1113,7 @@ function FormBuilderSection({ seriesId }: { seriesId: string }) {
               {/* Row 1: label (full width) */}
               <input
                 type="text"
-                placeholder="Veldlabel, bijv. 'Telefoonnummer'"
+                placeholder={t("field_label_placeholder")}
                 value={field.label}
                 onChange={(e) =>
                   updateField(field._key, { label: e.target.value })
@@ -1136,9 +1135,9 @@ function FormBuilderSection({ seriesId }: { seriesId: string }) {
                     });
                   }}
                 >
-                  {FIELD_TYPES.map((t) => (
-                    <option key={t.value} value={t.value}>
-                      {t.label}
+                  {FIELD_TYPES.map((ft) => (
+                    <option key={ft.value} value={ft.value}>
+                      {t(ft.labelKey)}
                     </option>
                   ))}
                 </NativeSelect>
@@ -1153,7 +1152,7 @@ function FormBuilderSection({ seriesId }: { seriesId: string }) {
                     }
                     className="accent-tennis-green disabled:opacity-60"
                   />
-                  Verplicht
+                  {t("field_required")}
                 </label>
 
                 <div className="flex items-center gap-1 ml-auto">
@@ -1190,7 +1189,7 @@ function FormBuilderSection({ seriesId }: { seriesId: string }) {
                     <div key={optIdx} className="flex items-center gap-2">
                       <input
                         type="text"
-                        placeholder={`Optie ${optIdx + 1}`}
+                        placeholder={t("option_placeholder", { number: optIdx + 1 })}
                         value={opt}
                         onChange={(e) =>
                           updateOption(field._key, optIdx, e.target.value)
@@ -1212,7 +1211,7 @@ function FormBuilderSection({ seriesId }: { seriesId: string }) {
                     className="flex items-center gap-1 text-xs text-tennis-green hover:underline"
                   >
                     <Plus size={11} />
-                    Optie toevoegen
+                    {t("add_option")}
                   </button>
                 </div>
               )}
@@ -1227,7 +1226,7 @@ function FormBuilderSection({ seriesId }: { seriesId: string }) {
             className="flex items-center gap-1.5 px-3 py-2 border border-gray-200 text-xs font-medium text-gray-600 rounded-lg hover:bg-gray-50 transition-colors"
           >
             <Plus size={12} />
-            Veld toevoegen
+            {t("add_field")}
           </button>
           <button
             type="button"
@@ -1236,17 +1235,15 @@ function FormBuilderSection({ seriesId }: { seriesId: string }) {
             className="flex items-center gap-1.5 px-4 py-2 bg-tennis-green text-white text-xs font-semibold rounded-lg hover:bg-tennis-green/90 transition-colors disabled:opacity-60"
           >
             {saveMutation.isPending
-              ? "Opslaan..."
+              ? t("saving")
               : saveMutation.isSuccess
-                ? "Opgeslagen ✓"
-                : "Formulier opslaan"}
+                ? `${t("saved")} ✓`
+                : t("save_form")}
           </button>
         </div>
 
         {saveMutation.isError && (
-          <p className="text-xs text-red-500">
-            Opslaan mislukt. Probeer opnieuw.
-          </p>
+          <p className="text-xs text-red-500">{t("save_error")}</p>
         )}
       </div>
     </div>

--- a/frontend/app/(dashboard)/dashboard/lessons/[id]/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/lessons/[id]/page.tsx
@@ -944,6 +944,16 @@ const FIELD_TYPES = [
 // Field types that carry a list of choices stored in `options`.
 const OPTION_FIELD_TYPES = [2, 4];
 
+// Starter buckets for the age-category question that every new enrollment form
+// gets by default. The admin can edit these or remove the field entirely.
+const DEFAULT_AGE_BUCKETS = [
+  "6-8 jaar",
+  "9-11 jaar",
+  "12-14 jaar",
+  "15-17 jaar",
+  "Volwassenen",
+];
+
 interface DraftField extends SaveFormFieldRequest {
   _key: string;
 }
@@ -963,6 +973,7 @@ function FormBuilderSection({ seriesId }: { seriesId: string }) {
   useEffect(() => {
     if (!loaded && existingForm !== undefined) {
       if (existingForm) {
+        // Respect what was saved — including an admin who removed the age field.
         setFields(
           existingForm.fields.map((f) => ({
             _key: f.id,
@@ -974,10 +985,23 @@ function FormBuilderSection({ seriesId }: { seriesId: string }) {
             options: f.options ?? undefined,
           })),
         );
+      } else {
+        // No form configured yet: pre-add a default (removable) age-category
+        // question so age-aware matching is on by default.
+        setFields([
+          {
+            _key: Math.random().toString(36).slice(2),
+            label: t("type_age_category"),
+            type: 4,
+            isRequired: true,
+            order: 0,
+            options: [...DEFAULT_AGE_BUCKETS],
+          },
+        ]);
       }
       setLoaded(true);
     }
-  }, [existingForm, loaded]);
+  }, [existingForm, loaded, t]);
 
   const saveMutation = useMutation({
     mutationFn: () => {

--- a/frontend/app/(dashboard)/dashboard/lessons/[id]/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/lessons/[id]/page.tsx
@@ -937,7 +937,11 @@ const FIELD_TYPES = [
   { value: 1, label: "Vrije tekst" },
   { value: 2, label: "Meerkeuze" },
   { value: 3, label: "Ja/Nee" },
+  { value: 4, label: "Leeftijdscategorie" },
 ];
+
+// Field types that carry a list of choices stored in `options`.
+const OPTION_FIELD_TYPES = [2, 4];
 
 interface DraftField extends SaveFormFieldRequest {
   _key: string;
@@ -979,9 +983,10 @@ function FormBuilderSection({ seriesId }: { seriesId: string }) {
         id: f.id,
         label: f.label,
         type: f.type,
-        isRequired: f.isRequired,
+        // The age-category question is always mandatory (the server enforces this too).
+        isRequired: f.type === 4 ? true : f.isRequired,
         order: i,
-        options: f.type === 2 ? f.options : undefined,
+        options: OPTION_FIELD_TYPES.includes(f.type) ? f.options : undefined,
       }));
       return saveEnrollmentForm(seriesId, payload);
     },
@@ -1121,12 +1126,15 @@ function FormBuilderSection({ seriesId }: { seriesId: string }) {
               <div className="flex items-center gap-2">
                 <NativeSelect
                   value={field.type}
-                  onChange={(e) =>
+                  onChange={(e) => {
+                    const newType = parseInt(e.target.value);
                     updateField(field._key, {
-                      type: parseInt(e.target.value),
-                      options: undefined,
-                    })
-                  }
+                      type: newType,
+                      // Age categories start with two empty buckets; other types drop options.
+                      options: newType === 4 ? ["", ""] : undefined,
+                      isRequired: newType === 4 ? true : field.isRequired,
+                    });
+                  }}
                 >
                   {FIELD_TYPES.map((t) => (
                     <option key={t.value} value={t.value}>
@@ -1138,11 +1146,12 @@ function FormBuilderSection({ seriesId }: { seriesId: string }) {
                 <label className="flex items-center gap-1.5 text-xs text-gray-600 cursor-pointer select-none">
                   <input
                     type="checkbox"
-                    checked={field.isRequired}
+                    checked={field.type === 4 ? true : field.isRequired}
+                    disabled={field.type === 4}
                     onChange={(e) =>
                       updateField(field._key, { isRequired: e.target.checked })
                     }
-                    className="accent-tennis-green"
+                    className="accent-tennis-green disabled:opacity-60"
                   />
                   Verplicht
                 </label>
@@ -1174,8 +1183,8 @@ function FormBuilderSection({ seriesId }: { seriesId: string }) {
                 </div>
               </div>
 
-              {/* Options for MultipleChoice */}
-              {field.type === 2 && (
+              {/* Options for MultipleChoice and Age category buckets */}
+              {OPTION_FIELD_TYPES.includes(field.type) && (
                 <div className="space-y-2 pt-1 border-t border-gray-100">
                   {(field.options ?? []).map((opt, optIdx) => (
                     <div key={optIdx} className="flex items-center gap-2">

--- a/frontend/app/(dashboard)/dashboard/lessons/[id]/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/lessons/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useEffect, useState } from "react";
+import { use, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -963,6 +963,11 @@ function FormBuilderSection({ seriesId }: { seriesId: string }) {
   const queryClient = useQueryClient();
   const [fields, setFields] = useState<DraftField[]>([]);
   const [loaded, setLoaded] = useState(false);
+  // Set when we seed the default age question for a series with no form yet,
+  // so we can persist it automatically (no manual "save" needed).
+  const [pendingAutoSave, setPendingAutoSave] = useState(false);
+  // Guards against a double auto-save (React StrictMode re-runs effects in dev).
+  const autoSaveStarted = useRef(false);
 
   const { data: existingForm } = useQuery({
     queryKey: ["enrollmentForm", seriesId],
@@ -987,7 +992,8 @@ function FormBuilderSection({ seriesId }: { seriesId: string }) {
         );
       } else {
         // No form configured yet: pre-add a default (removable) age-category
-        // question so age-aware matching is on by default.
+        // question so age-aware matching is on by default, and persist it
+        // automatically so the public enrollment form has it without a manual save.
         setFields([
           {
             _key: Math.random().toString(36).slice(2),
@@ -998,6 +1004,7 @@ function FormBuilderSection({ seriesId }: { seriesId: string }) {
             options: [...DEFAULT_AGE_BUCKETS],
           },
         ]);
+        setPendingAutoSave(true);
       }
       setLoaded(true);
     }
@@ -1020,6 +1027,16 @@ function FormBuilderSection({ seriesId }: { seriesId: string }) {
       queryClient.invalidateQueries({ queryKey: ["enrollmentForm", seriesId] });
     },
   });
+
+  // Persist the seeded default age question once, so it goes live on the public
+  // enrollment form without the admin having to press save.
+  useEffect(() => {
+    if (pendingAutoSave && fields.length > 0 && !autoSaveStarted.current) {
+      autoSaveStarted.current = true;
+      setPendingAutoSave(false);
+      saveMutation.mutate();
+    }
+  }, [pendingAutoSave, fields, saveMutation]);
 
   function addField() {
     setFields((prev) => [

--- a/frontend/app/(public)/enroll/[seriesId]/page.tsx
+++ b/frontend/app/(public)/enroll/[seriesId]/page.tsx
@@ -43,6 +43,7 @@ import Link from "next/link";
 const FIELD_TYPE_TEXT = 1;
 const FIELD_TYPE_MULTIPLE_CHOICE = 2;
 const FIELD_TYPE_YES_NO = 3;
+const FIELD_TYPE_AGE_CATEGORY = 4;
 
 const PREF_AVAILABLE = 1;
 const PREF_PREFERRED = 2;
@@ -282,7 +283,11 @@ export default function EnrollPage() {
     const value = fieldValues[field.id] ?? "";
     const hasError = !!fieldErrors[field.id];
 
-    if (field.type === FIELD_TYPE_MULTIPLE_CHOICE && field.options) {
+    if (
+      (field.type === FIELD_TYPE_MULTIPLE_CHOICE ||
+        field.type === FIELD_TYPE_AGE_CATEGORY) &&
+      field.options
+    ) {
       return (
         <div key={field.id} className="space-y-1.5">
           <label className="block text-sm font-medium text-gray-700">

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -200,11 +200,21 @@
     "type_text": "Vrije tekst",
     "type_multiple_choice": "Meerkeuze",
     "type_yes_no": "Ja/Nee",
+    "type_age_category": "Leeftijdscategorie",
     "options": "Opties",
     "add_option": "Optie toevoegen",
     "no_fields": "Nog geen aangepaste velden. Voeg een veld toe.",
     "saving": "Opslaan...",
-    "saved": "Formulier opgeslagen"
+    "saved": "Formulier opgeslagen",
+    "predefined_fields_hint": "Vaste velden (altijd zichtbaar)",
+    "pf_firstname": "Voornaam",
+    "pf_lastname": "Achternaam",
+    "pf_email": "E-mailadres",
+    "pf_enrollment_type": "Inschrijvingstype",
+    "pf_availability": "Beschikbaarheid",
+    "field_label_placeholder": "Veldlabel, bijv. 'Telefoonnummer'",
+    "option_placeholder": "Optie {number}",
+    "save_error": "Opslaan mislukt. Probeer opnieuw."
   },
   "lessonWizard": {
     "availableBadge": "beschikbaar",


### PR DESCRIPTION
Closes #98.

## What

Adds a mandatory **age category** question to lesson-series enrollment forms, and makes the matching algorithm respect it so students from different age buckets are never auto-grouped together (e.g. a 4-year-old won't be matched with a 9-year-old).

## Why

Per #98: clubs need to group students by age. Without this, the scheduler could merge a young child into a group of much older kids. The age category is now on by default so clubs don't have to remember to add it.

## How it works

**Form**
- New `FormFieldType.AgeCategory` (no migration — stored as `int`, buckets reuse the existing `Options` column).
- The question is **always required** once present — forced server-side in `SaveFormAsync` regardless of the client, plus submit-time validation. A form may have at most one age field (≥2 buckets).
- **Default-on**: when the form builder opens a series with no form yet, it seeds a default age question (`6-8 / 9-11 / 12-14 / 15-17 jaar / Volwassenen`) and **auto-persists** it — so it appears on the public enrollment form without a manual save. Buckets are editable and the field is removable (e.g. adults-only clubs). A saved form is respected as-is, including an admin who deleted the field.
  - This is safe because the only way to obtain a series enrollment link is the detail page (`/dashboard/lessons/[id]`), and opening it triggers the auto-save — so the age question is always live before any link can be shared.

**Matching (`SchedulingAlgorithm`)**
- `EnrollmentUnit` now carries an `AgeCategory`, read from each enrollment's form responses in `PlanningProposalBuilder`.
- **Slot age-locking**: the first age-bearing unit placed in a slot locks it to that bucket; subsequent auto-grouping (auto-merge, leftover-solo placement, open-group placement) refuses mismatched buckets.
- `null` age (no field configured, or — defensively — unanswered) is unconstrained, so behavior is identical to before when the feature is unused.
- A student with no age-compatible slot falls through to the existing conflict path (left unassigned, flagged) rather than being mis-grouped.
- Pre-formed (manual) groups with mixed ages are treated as unconstrained — only *automatic* matching is age-gated, per the issue wording.

**i18n**
- The enrollment form builder strings (field-type labels incl. the new one, badges, buttons, messages) now use the existing `formBuilder` next-intl namespace instead of hardcoded Dutch.

## Testing

- **Backend unit tests**: 286 passing, including 11 new algorithm/validator tests (same-age merges, different-age separation, group/solo gating, feature-off parity, one-age-field / ≥2-buckets / value-required rules).
- **Reset + seed E2E gate** (the project's "done" bar): clean DB migrate → age field persisted (required, buckets) → all 11 planning enrollments submitted *with* the mandatory answer → planning generated. Verified via API that **every scheduled slot is age-homogeneous with 0 conflicts** (e.g. Emma + Jules grouped as `14-17`, Noor + Kevin as `Volwassenen`).
- **Live browser check**: opening a previously formless series auto-persisted the default form, and the public enrollment form then rendered "Leeftijdscategorie" with all five buckets.

## Reviewer notes

- No DB migration and no repository changes for matching — planning already eager-loads `FormResponses`.
- The seed (`seed-data.json` / `seed-demo-data.py`) was updated to exercise the path; auto-merge demo pairs share a bucket so existing demo merges are unchanged.
- Scope note: #98 framed the question as opt-in ("kan / als dit gebruikt wordt"); this PR makes it **default-on** (removable), which was a deliberate product decision.
